### PR TITLE
BIG-17855: functions to extract config variables for LESS

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -176,8 +176,7 @@ internals.scssCompiler = function (options, callback) {
  * @param callback
  */
 internals.lessCompiler = function (options, callback) {
-    var themeVariables = '',
-        lessOptions = {
+    var lessOptions = {
             filename: options.file,
             compress: false,
             sourceMap: {
@@ -185,19 +184,62 @@ internals.lessCompiler = function (options, callback) {
             }
         };
 
-    Fs.readFile(options.file, {encoding: 'utf-8'}, function (err, content) {
-        if (err) {
-            return callback(err);
+    function stencilNumber(nameObj, unitObj) {
+        var name = nameObj.value,
+            unit = unitObj.value || 'px',
+            ret;
+
+        if (options.themeSettings[name]) {
+            ret = new Less.tree.Dimension(options.themeSettings[name], unit);
+        } else {
+            ret = null;
         }
 
-        _.forOwn(options.themeSettings, function(val, key) {
-            themeVariables += '@themeSetting-' + key + ': ' + val + ';\n';
-        });
+        return ret;
+    }
 
-        Less.render(themeVariables + content, lessOptions).then(function(result) {
-            callback(null, result.css);
-        }, function(err) {
-            callback('LESS Error: ' + err.message + ' at ' + (err.filename + '@' + err.line + ':' + err.column));
-        });
+    function stencilString(nameObj) {
+        var name = nameObj.value,
+            ret;
+
+        if (options.themeSettings[name]) {
+            ret = new Less.tree.Anonymous(options.themeSettings[name]);
+        } else {
+            ret = null;
+        }
+
+        return ret;
+    }
+
+    function stencilColor(nameObj) {
+        var name = nameObj.value,
+            val,
+            ret;
+
+        if (options.themeSettings[name]) {
+            val = options.themeSettings[name];
+
+            if (val[0] === '#') {
+                val = val.substr(1);
+            }
+
+            ret = new Less.tree.Color(val);
+        } else {
+            ret = null;
+        }
+
+        return ret;
+    }
+
+    Less.functions.functionRegistry.addMultiple({
+        'stencil-number': stencilNumber,
+        'stencil-string': stencilString,
+        'stencil-color': stencilColor
+    });
+
+    Less.render(options.data, lessOptions).then(function(result) {
+        callback(null, result.css);
+    }, function(err) {
+        callback('LESS Error: ' + err.message + ' at ' + (err.filename + '@' + err.line + ':' + err.column));
     });
 };


### PR DESCRIPTION
As part of the work for theme variation, I notice LESS doesn't have the helper functions to extract values from Stencil config file (they are exposed as variables instead). This PR attempts to recreate the same SASS functions for LESS. Also, it seems like the we don't have to access the filesystem here anymore?

@meenie can you have a look?
