### PR TITLE
Fixed bug where 3-word fonts wont parse correctly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -214,7 +214,7 @@ internals.googleFontParser = function(value, type) {
     }
 
     formattedString = split[index].split(',')[0];
-    formattedString = formattedString.replace('+', ' ');
+    formattedString = formattedString.replace(/\+/g, ' ');
 
     return new Sass.types.String(formattedString);
 };


### PR DESCRIPTION
Fixed bug where google fonts with 3 words name were not being parsed correctly.

@hegrec @haubc 
