### PR TITLE
BIG-25633: Now returning font-family wrapped in quotes

### DIFF
--- a/lib/styles.js
+++ b/lib/styles.js
@@ -255,7 +255,8 @@ module.exports = function StencilStyles() {
      * @returns {*}
      */
     self.defaultFontParser = function(value, type) {
-        var index = type === 'family' ? 0 : 1,
+        var typeFamily = type === 'family',
+            index = typeFamily ? 0 : 1,
             formattedString,
             split;
 
@@ -273,6 +274,16 @@ module.exports = function StencilStyles() {
         formattedString = split[index].split(',')[0];
         formattedString = formattedString.replace(/\+/g, ' ');
 
-        return new Sass.types.String(formattedString);
+        // Make sure the string has no quotes in it
+        formattedString = formattedString.replace(/'|"/g, '');
+
+        if (typeFamily) {
+            // Wrap the string in quotes since Sass type String
+            // works with quotes and without quotes (it won't add them)
+            // and we end up with font-family: Open Sans with no quotes
+            formattedString = '"' + formattedString + '"';
+        }
+
+        return Sass.types.String(formattedString);
     };
 };

--- a/test/styles.js
+++ b/test/styles.js
@@ -220,7 +220,7 @@ describe('Stencil-Styles Plugin', function () {
         it('should return the font family name', function(done) {
             var result = stencilStyles.defaultFontParser(nativeFont, 'family');
 
-            expect(result.getValue()).to.equal('Times New Roman');
+            expect(result.getValue()).to.equal('"Times New Roman"');
 
             done();
         });


### PR DESCRIPTION
This wraps the return value of fontFamily with quotes to avoid issues like the one where if the name of the font family matches a color it will change it to hex in production.

https://github.com/sass/sass/issues/874  Related

@bc-jstoffan @mcampa 
