### PR TITLE
CHECKOUT-929: add stencilImage(image_key, image_size_key)

### DIFF
--- a/lib/styles.js
+++ b/lib/styles.js
@@ -137,6 +137,21 @@ module.exports = function StencilStyles() {
             return ret;
         };
 
+        sassFunctions['stencilImage($image, $size)'] = function(imageObj, sizeObj) {
+            var sizeRegex = /^\d+x\d+$/g,
+                image = imageObj.getValue(),
+                size = sizeObj.getValue(),
+                ret;
+
+            if (themeSettings[image].indexOf('{:size}') !== -1 && sizeRegex.test(themeSettings[size])) {
+                ret = new Sass.types.String(themeSettings[image].replace('{:size}', themeSettings[size]));
+            } else {
+                ret = Sass.NULL;
+            }
+
+            return ret;
+        };
+
         sassFunctions['stencilFontFamily($name)'] = function(nameObj) {
             return self.stencilFont(themeSettings[nameObj.getValue()], 'family');
         };


### PR DESCRIPTION
_should be merged with PROJECT-1134_

<img width="1436" alt="screen shot 2016-09-07 at 4 13 22 pm" src="https://cloud.githubusercontent.com/assets/8165665/18331774/4517bb2e-7516-11e6-8faf-48672be62b40.png">

What...
replace the **{:size}** part of an **cdn image url** with the value of the associated **image size**

Ex...
stencil checkout.scss file: 

```
.checkoutHeader {
  background-image: url(stencilImage('uco_custom_background_image', 'uco_custom_background_image_size'));
}
```

return ex:

```
.checkoutHeader {
  background-image: url('https://cdn.bcapp.dev/bcapp/io3nxwv0/images/stencil/250x100/uploaded_image.png');
}
```

@bigcommerce/checkout @mcampa @bigcommerce/ui-platform 
