### PR TITLE
STENCIL-3125 Upgrade autoprefixer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
-# Stencil Styles - Compiles SCSS On-The-Fly for the Stencil Framework
+# Stencil Styles
+## Compiles SCSS On-The-Fly for the Stencil Framework
 
 ### Usage
 *This is assuming you are using Glue and have added `stencil-styles` to your manifest file*
 
 ```javascript
-server.plugins.StencilStyles.compile(compiler, {
+const StencilStyles = require('@bigcommerce/stencil-styles');
+
+const stencilStyles = new StencilStyles;
+
+stencilStyles.compile(compiler, {
     data: '', //Initial SCSS content,
     files: {}, //An object of all files needed to compile using key as the path name and val as the content
     dest: '', // `dest` option for SCSS
@@ -13,7 +18,7 @@ server.plugins.StencilStyles.compile(compiler, {
         cascade: true,
         browsers: ["> 5% in US"]
     }
-}, function (err, css) {
+}, (err, css) => {
     // `css` will be the compiled SCSS
 });
 ```
@@ -47,4 +52,3 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -29,23 +29,19 @@ function StencilStyles() {
             };
 
             this.files = options.files || {};
-            this.scssCompiler(compilerOptions, doneCompiling);
+            this.scssCompiler(compilerOptions, (err, css) => {
+                if (err) {
+                    return callback(err);
+                }
+
+                callback(null, this.autoPrefix(css, options.autoprefixerOptions));
+            });
             break;
-        }
-
-        function doneCompiling(err, css) {
-            if (err) {
-                return callback(err);
-            }
-
-            const prefixedCss = this.autoPrefix(css, options.autoprefixerOptions);
-
-            callback(null, prefixedCss);
         }
     };
 
     this.autoPrefix = (css, autoprefixerOptions) => {
-        const payload = typeof css === 'string' ? css : '';
+        const payload = typeof css === 'string' || css instanceof Buffer ? css : '';
         var output = css;
 
         try {

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const _ = require('lodash');
-const autoprefixer = require('autoprefixer-core');
+const autoprefixer = require('autoprefixer');
+const postcss = require('postcss');
 const path = require('path');
 const sass = require('node-sass');
 
@@ -37,10 +38,23 @@ function StencilStyles() {
                 return callback(err);
             }
 
-            const prefixedCss = autoprefixer(options.autoprefixerOptions).process(css).css;
+            const prefixedCss = this.autoPrefix(css, options.autoprefixerOptions);
 
             callback(null, prefixedCss);
         }
+    };
+
+    this.autoPrefix = (css, autoprefixerOptions) => {
+        const payload = typeof css === 'string' ? css : '';
+        var output = css;
+
+        try {
+            output = postcss([autoprefixer(autoprefixerOptions)]).process(payload).css;
+        } catch (e) {
+            // invalid css
+        }
+
+        return output;
     };
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-styles",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Compiles SCSS for the Stencil Framework",
   "main": "lib/index.js",
   "scripts": {
@@ -20,9 +20,10 @@
   },
   "homepage": "https://github.com/bigcommerce/stencil-styles#readme",
   "dependencies": {
-    "autoprefixer-core": "^5.2.1",
+    "autoprefixer": "^6.7.3",
     "lodash": "^3.10.1",
-    "node-sass": "3.4.2"
+    "node-sass": "3.4.2",
+    "postcss": "^5.2.14"
   },
   "devDependencies": {
     "code": "^1.4.0",

--- a/test/styles.js
+++ b/test/styles.js
@@ -43,6 +43,27 @@ describe('Stencil-Styles Plugin', () => {
         });
     });
 
+    describe('autoPrefix', () => {
+        it('should add vendor prefixes to css rules', done => {
+            const prefixedCss = stencilStyles.autoPrefix('a { transform: scale(0.5); }', {});
+            expect(prefixedCss).to.contain(['-webkit-transform']);
+            done();
+        });
+
+        it('should return an empty string if input is not a string', done => {
+            expect(stencilStyles.autoPrefix(null)).to.be.equal('');
+            expect(stencilStyles.autoPrefix({})).to.be.equal('');
+            expect(stencilStyles.autoPrefix(undefined)).to.be.equal('');
+            done();
+        });
+
+        it('should return the input string if not valid css', done => {
+            const notCss = 'this is not css';
+            expect(stencilStyles.autoPrefix(notCss)).to.be.equal(notCss);
+            done();
+        });
+    });
+
     describe('compileCss()', () => {
         var callback;
 


### PR DESCRIPTION
Autoprefixer library is deprecated and is printing a warning message in the stencil-cli console everytime scss is precompiled


Warning:
```
Autoprefixer's process() method is deprecated and will removed in next major release. Use postcss([autoprefixer]).process() instead
```

https://jira.bigcommerce.com/browse/STENCIL-3125

@bigcommerce/stencil-team 