### PR TITLE
ARCH-221 use @bigcommerce/node-sass (Node 6 & 7 compatible)

### DIFF
--- a/lib/styles.js
+++ b/lib/styles.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 const autoprefixer = require('autoprefixer');
 const postcss = require('postcss');
 const path = require('path');
-const sass = require('node-sass');
+const sass = require('@bigcommerce/node-sass');
 
 function StencilStyles() {
     this.files = {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-styles",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Compiles SCSS for the Stencil Framework",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
   },
   "homepage": "https://github.com/bigcommerce/stencil-styles#readme",
   "dependencies": {
+    "@bigcommerce/node-sass": "git://github.com/bigcommerce-labs/node-sass.git#v3.4.3",
     "autoprefixer": "^6.7.3",
     "lodash": "^3.10.1",
-    "node-sass": "3.4.2",
     "postcss": "^5.2.14"
   },
   "devDependencies": {

--- a/test/styles.js
+++ b/test/styles.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 const Code = require('code');
 const Lab = require('lab');
 const sinon = require('sinon');
-const Sass = require('node-sass');
+const Sass = require('@bigcommerce/node-sass');
 const StencilStyles = require('../lib/styles');
 const lab = exports.lab = Lab.script();
 const afterEach = lab.afterEach;


### PR DESCRIPTION
This will allow us to upgrade to node 6+

Is using a node-sass fork https://github.com/bigcommerce-labs/node-sass/releases/tag/v3.4.3

@bigcommerce/stencil-team 