### PR TITLE
Node.js 8

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,7 +7,7 @@
     "modules": true
   },
   "env": {
-    "node": true,
+    "node": true
   },
   "globals": {
 
@@ -15,6 +15,7 @@
   "rules": {
     "curly": 2,
     "no-eq-null": 2,
+    "comma-dangle": [ 2, "always-multiline" ],
     "wrap-iife": [ 2, "any" ],
     "new-cap": 2,
     "no-caller": 2,
@@ -22,6 +23,6 @@
     "no-debugger": 2,
     "no-undef": 2,
     "no-unused-vars": 2,
-    "indent": [2, 4],
+    "indent": [2, 4]
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: node_js
 sudo: false
 node_js:
   - 4
+  - 5
+  - 6
+  - 7
+  - 8
 script:
   - npm install
   - npm test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,22 @@
+environment:
+  matrix:
+    - nodejs_version: "8"
+    - nodejs_version: "7"
+    - nodejs_version: "6"
+    - nodejs_version: "5"
+    - nodejs_version: "4"
+
+platform:
+  - x86
+  - x64
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - npm install
+
+test_script:
+  - node --version
+  - npm --version
+  - npm test
+
+build: off

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -25,7 +25,6 @@ function StencilStyles() {
                 dest: options.dest,
                 sourceMap: options.sourceMap,
                 functions: this.scssFunctions(options.themeSettings),
-                importer: this.scssImporter,
             };
 
             this.files = options.files || {};
@@ -64,7 +63,7 @@ function StencilStyles() {
             data: options.data,
             outFile: options.dest,
             functions: options.functions,
-            importer: options.importer,
+            importer: this.scssImporter,
             sourceMap: options.sourceMap,
             sourceMapEmbed: options.sourceMap,
         };
@@ -165,36 +164,26 @@ function StencilStyles() {
     };
 
     /**
-     * The custom importer function to pass to the node-sass compiler
+     * The custom importer callback function to pass to the node-sass compiler
      *
      * @param url
      * @param prev
      * @returns object
      */
     this.scssImporter = (url, prev) => {
-        const files = this.files;
-        const prevParts = path.parse(prev);
-        const urlParts = path.parse(url);
-        const fullUrls = this.fullUrls;
-        var fullUrl = url + (urlParts.ext === 'scss' ? '' : '.scss');
-        var basePath;
-        var possiblePaths;
+        let fullUrl = url + (url.match(/.*\.scss$/) ? '' : '.scss');
 
         if (prev !== 'stdin') {
-            basePath = prevParts.dir;
+            fullUrl = path.join(path.parse(prev).dir, fullUrl);
         }
 
-        if (basePath) {
-            fullUrl = path.join(basePath, fullUrl);
-        }
-
-        if (files[fullUrl] === undefined) {
-            possiblePaths = _.keys(_.pick(fullUrls, val => val.indexOf(prev) !== -1));
+        if (this.files[fullUrl] === undefined) {
+            const possiblePaths = _.keys(_.pick(this.fullUrls, val => val.indexOf(prev) !== -1));
 
             _.each(possiblePaths, possiblePath => {
                 const possibleFullUrl = path.join(path.parse(possiblePath).dir, url);
 
-                if (files[possibleFullUrl] !== undefined) {
+                if (this.files[possibleFullUrl] !== undefined) {
                     fullUrl = possibleFullUrl;
 
                     // We found it so lets kick out of the loop
@@ -203,20 +192,20 @@ function StencilStyles() {
             });
         }
 
-        if (files[fullUrl] === undefined) {
+        if (this.files[fullUrl] === undefined) {
             return new Error(fullUrl + ' doesn\'t exist!');
-        } else {
-            if (! fullUrls[fullUrl]) {
-                fullUrls[fullUrl] = [url];
-            } else if (fullUrls[fullUrl].indexOf(url) === -1) {
-                fullUrls[fullUrl].push(url)
-            }
-
-            return {
-                file: fullUrl,
-                contents: files[fullUrl]
-            };
         }
+
+        if (!this.fullUrls[fullUrl]) {
+            this.fullUrls[fullUrl] = [url];
+        } else if (this.fullUrls[fullUrl].indexOf(url) === -1) {
+            this.fullUrls[fullUrl].push(url);
+        }
+
+        return {
+            file: fullUrl,
+            contents: this.files[fullUrl],
+        };
     };
 
     /**

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -178,16 +178,16 @@ function StencilStyles() {
         }
 
         if (this.files[fullUrl] === undefined) {
-            const possiblePaths = _.keys(_.pick(this.fullUrls, val => val.indexOf(prev) !== -1));
+            const possiblePaths = Object.keys(_.pick(this.fullUrls, val => val.indexOf(prev) !== -1));
 
-            _.each(possiblePaths, possiblePath => {
+            possiblePaths.find(possiblePath => {
                 const possibleFullUrl = path.join(path.parse(possiblePath).dir, url);
 
                 if (this.files[possibleFullUrl] !== undefined) {
                     fullUrl = possibleFullUrl;
 
                     // We found it so lets kick out of the loop
-                    return false;
+                    return true;
                 }
             });
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2623 @@
+{
+  "name": "@bigcommerce/stencil-styles",
+  "version": "1.1.0",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@bigcommerce/node-sass": {
+      "version": "git://github.com/bigcommerce-labs/node-sass.git#4ea0b8d5f7c418d5bf20b07e395b2609e020bb8b"
+    },
+    "abbrev": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+      "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8="
+    },
+    "acorn": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
+      "integrity": "sha1-xGDfCEkUY/AozLguqzcwvwEIez0=",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
+      }
+    },
+    "ajv": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY="
+    },
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "dev": true
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "aproba": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+      "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s="
+    },
+    "are-we-there-yet": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0="
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+    },
+    "assert-plus": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
+    },
+    "async-foreach": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+      "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "autoprefixer": {
+      "version": "6.7.7",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+      "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
+      "dependencies": {
+        "browserslist": {
+          "version": "1.7.7",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+          "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+          "dependencies": {
+            "electron-to-chromium": {
+              "version": "1.3.9",
+              "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.9.tgz",
+              "integrity": "sha1-2xy6KiauvMovf1uLA0VURoYJFX0="
+            }
+          }
+        },
+        "caniuse-db": {
+          "version": "1.0.30000666",
+          "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000666.tgz",
+          "integrity": "sha1-lR7Z89O/qgigba+7UImrB8zmq5A="
+        },
+        "normalize-range": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+          "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
+        },
+        "num2fraction": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+          "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
+        },
+        "postcss-value-parser": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+          "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU="
+        }
+      }
+    },
+    "aws-sign2": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+    },
+    "balanced-match": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "optional": true
+    },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo="
+    },
+    "boom": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
+    },
+    "bossy": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/bossy/-/bossy-3.0.4.tgz",
+      "integrity": "sha1-+a6fJugbQaMY9O4Ng2huSlwlB7k=",
+      "dev": true,
+      "dependencies": {
+        "hoek": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.1.1.tgz",
+          "integrity": "sha1-nMVz/7ore0CPtenCoTeWvpTN3Ok=",
+          "dev": true
+        }
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+      "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k="
+    },
+    "buffer-shims": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+    },
+    "camelcase": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+    },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc="
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dev": true,
+      "optional": true
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
+    },
+    "cliui": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0="
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "code": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/code/-/code-4.0.0.tgz",
+      "integrity": "sha1-7HlT/XkZAFLOoladY9e0wNR8AgQ=",
+      "dev": true,
+      "dependencies": {
+        "hoek": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.1.1.tgz",
+          "integrity": "sha1-nMVz/7ore0CPtenCoTeWvpTN3Ok=",
+          "dev": true
+        }
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc="
+    },
+    "config-chain": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+      "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI="
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cross-spawn": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-2.2.3.tgz",
+      "integrity": "sha1-+sViAt/T0N2GF3jy2iA79DS7ghw="
+    },
+    "cross-spawn-async": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
+      "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw="
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o="
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "diff": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "dev": true
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "optional": true
+    },
+    "error-ex": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "eslint": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
+      "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
+      "dev": true,
+      "dependencies": {
+        "babel-code-frame": {
+          "version": "6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+          "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+          "dev": true,
+          "dependencies": {
+            "js-tokens": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+              "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
+              "dev": true
+            }
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+              "dev": true
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+              "dev": true
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+              "dev": true,
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                  "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                  "dev": true
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true,
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                  "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                  "dev": true
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
+            }
+          }
+        },
+        "concat-stream": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+          "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+          "dev": true,
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "2.2.9",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+              "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+              "dev": true,
+              "dependencies": {
+                "buffer-shims": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+                  "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+                  "dev": true
+                },
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                  "dev": true
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                  "dev": true
+                },
+                "process-nextick-args": {
+                  "version": "1.0.7",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                  "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                  "dev": true
+                },
+                "string_decoder": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+                  "integrity": "sha1-8G9BFXtmTYYGn4S9vcmw2KsoFmc=",
+                  "dev": true
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                  "dev": true
+                }
+              }
+            },
+            "typedarray": {
+              "version": "0.0.6",
+              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+              "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+              "dev": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.6.tgz",
+          "integrity": "sha1-qfpvvpykPPHnn3O3XAGJy7fW21o=",
+          "dev": true,
+          "dependencies": {
+            "ms": {
+              "version": "0.7.3",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+              "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8=",
+              "dev": true
+            }
+          }
+        },
+        "doctrine": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+          "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+          "dev": true,
+          "dependencies": {
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "dev": true
+            }
+          }
+        },
+        "escope": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+          "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+          "dev": true,
+          "dependencies": {
+            "es6-map": {
+              "version": "0.1.5",
+              "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+              "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+              "dev": true,
+              "dependencies": {
+                "d": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+                  "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+                  "dev": true
+                },
+                "es5-ext": {
+                  "version": "0.10.16",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.16.tgz",
+                  "integrity": "sha1-HvGwTz0J22pdYwIm1iIC8uQl5Fo=",
+                  "dev": true
+                },
+                "es6-iterator": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+                  "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+                  "dev": true
+                },
+                "es6-set": {
+                  "version": "0.1.5",
+                  "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+                  "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+                  "dev": true
+                },
+                "es6-symbol": {
+                  "version": "3.1.1",
+                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+                  "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+                  "dev": true
+                },
+                "event-emitter": {
+                  "version": "0.3.5",
+                  "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+                  "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+                  "dev": true
+                }
+              }
+            },
+            "es6-weak-map": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+              "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+              "dev": true,
+              "dependencies": {
+                "d": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+                  "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+                  "dev": true
+                },
+                "es5-ext": {
+                  "version": "0.10.16",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.16.tgz",
+                  "integrity": "sha1-HvGwTz0J22pdYwIm1iIC8uQl5Fo=",
+                  "dev": true
+                },
+                "es6-iterator": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+                  "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+                  "dev": true
+                },
+                "es6-symbol": {
+                  "version": "3.1.1",
+                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+                  "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+                  "dev": true
+                }
+              }
+            },
+            "esrecurse": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
+              "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
+              "dev": true,
+              "dependencies": {
+                "estraverse": {
+                  "version": "4.1.1",
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
+                  "integrity": "sha1-9srKcokzqFDvkGYdDheYK6RxEaI=",
+                  "dev": true
+                },
+                "object-assign": {
+                  "version": "4.1.1",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                  "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "espree": {
+          "version": "3.4.3",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
+          "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
+          "dev": true,
+          "dependencies": {
+            "acorn": {
+              "version": "5.0.3",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
+              "integrity": "sha1-xGDfCEkUY/AozLguqzcwvwEIez0=",
+              "dev": true
+            },
+            "acorn-jsx": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+              "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+              "dev": true,
+              "dependencies": {
+                "acorn": {
+                  "version": "3.3.0",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+                  "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "esquery": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+          "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+          "dev": true
+        },
+        "estraverse": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+          "dev": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+          "dev": true
+        },
+        "file-entry-cache": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+          "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+          "dev": true,
+          "dependencies": {
+            "flat-cache": {
+              "version": "1.2.2",
+              "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
+              "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+              "dev": true,
+              "dependencies": {
+                "circular-json": {
+                  "version": "0.3.1",
+                  "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
+                  "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
+                  "dev": true
+                },
+                "del": {
+                  "version": "2.2.2",
+                  "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+                  "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+                  "dev": true,
+                  "dependencies": {
+                    "globby": {
+                      "version": "5.0.0",
+                      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+                      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+                      "dev": true,
+                      "dependencies": {
+                        "array-union": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+                          "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+                          "dev": true,
+                          "dependencies": {
+                            "array-uniq": {
+                              "version": "1.0.3",
+                              "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+                              "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "arrify": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+                          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "is-path-cwd": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+                      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+                      "dev": true
+                    },
+                    "is-path-in-cwd": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+                      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+                      "dev": true,
+                      "dependencies": {
+                        "is-path-inside": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+                          "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "pify": {
+                      "version": "2.3.0",
+                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                      "dev": true
+                    },
+                    "pinkie-promise": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                      "dev": true,
+                      "dependencies": {
+                        "pinkie": {
+                          "version": "2.0.4",
+                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "rimraf": {
+                      "version": "2.6.1",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+                      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+                      "dev": true
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "4.1.11",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                  "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+                  "dev": true
+                },
+                "write": {
+                  "version": "0.2.1",
+                  "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+                  "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+                  "dev": true
+                }
+              }
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+              "dev": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "dev": true,
+          "dependencies": {
+            "fs.realpath": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+              "dev": true
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+              "dev": true,
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                  "dev": true
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+              "dev": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+              "dev": true,
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.7",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+                  "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+                  "dev": true,
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.4.2",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+                      "dev": true
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+              "dev": true,
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                  "dev": true
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+              "dev": true
+            }
+          }
+        },
+        "globals": {
+          "version": "9.17.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
+          "integrity": "sha1-DAymltm5u2lNLlRwvTd3fKrVAoY=",
+          "dev": true
+        },
+        "ignore": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.0.tgz",
+          "integrity": "sha1-OBLSLL6RJfLCtJFXVaG4q9dFoAE=",
+          "dev": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+          "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+          "dev": true,
+          "dependencies": {
+            "ansi-escapes": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+              "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+              "dev": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "dev": true
+            },
+            "cli-cursor": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+              "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+              "dev": true,
+              "dependencies": {
+                "restore-cursor": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+                  "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+                  "dev": true,
+                  "dependencies": {
+                    "exit-hook": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+                      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+                      "dev": true
+                    },
+                    "onetime": {
+                      "version": "1.1.0",
+                      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+                      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "cli-width": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+              "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
+              "dev": true
+            },
+            "figures": {
+              "version": "1.7.0",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+              "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+              "dev": true,
+              "dependencies": {
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                  "dev": true
+                },
+                "object-assign": {
+                  "version": "4.1.1",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                  "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                  "dev": true
+                }
+              }
+            },
+            "readline2": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+              "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+              "dev": true,
+              "dependencies": {
+                "code-point-at": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                  "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+                  "dev": true
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                  "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                  "dev": true,
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                      "dev": true
+                    }
+                  }
+                },
+                "mute-stream": {
+                  "version": "0.0.5",
+                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+                  "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+                  "dev": true
+                }
+              }
+            },
+            "run-async": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+              "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+              "dev": true,
+              "dependencies": {
+                "once": {
+                  "version": "1.4.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                  "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                  "dev": true,
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "rx-lite": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+              "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+              "dev": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "dependencies": {
+                "code-point-at": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                  "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+                  "dev": true
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                  "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                  "dev": true,
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true
+            },
+            "through": {
+              "version": "2.3.8",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+              "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+              "dev": true
+            }
+          }
+        },
+        "is-my-json-valid": {
+          "version": "2.16.0",
+          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+          "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+          "dev": true,
+          "dependencies": {
+            "generate-function": {
+              "version": "2.0.0",
+              "resolved": "http://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+              "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+              "dev": true
+            },
+            "generate-object-property": {
+              "version": "1.2.0",
+              "resolved": "http://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+              "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+              "dev": true,
+              "dependencies": {
+                "is-property": {
+                  "version": "1.0.2",
+                  "resolved": "http://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                  "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+                  "dev": true
+                }
+              }
+            },
+            "jsonpointer": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+              "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+              "dev": true
+            },
+            "xtend": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+              "dev": true
+            }
+          }
+        },
+        "is-resolvable": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+          "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
+          "dev": true,
+          "dependencies": {
+            "tryit": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
+              "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
+              "dev": true
+            }
+          }
+        },
+        "js-yaml": {
+          "version": "3.8.4",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
+          "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
+          "dev": true,
+          "dependencies": {
+            "argparse": {
+              "version": "1.0.9",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+              "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+              "dev": true,
+              "dependencies": {
+                "sprintf-js": {
+                  "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                  "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+                  "dev": true
+                }
+              }
+            },
+            "esprima": {
+              "version": "3.1.3",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+              "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+              "dev": true
+            }
+          }
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+          "dev": true,
+          "dependencies": {
+            "jsonify": {
+              "version": "0.0.0",
+              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+              "dev": true
+            }
+          }
+        },
+        "levn": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+          "dev": true,
+          "dependencies": {
+            "prelude-ls": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+              "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+              "dev": true
+            },
+            "type-check": {
+              "version": "0.3.2",
+              "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+              "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+              "dev": true
+            }
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "dev": true
+            }
+          }
+        },
+        "natural-compare": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+          "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+          "dev": true
+        },
+        "optionator": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+          "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+          "dev": true,
+          "dependencies": {
+            "deep-is": {
+              "version": "0.1.3",
+              "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+              "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+              "dev": true
+            },
+            "fast-levenshtein": {
+              "version": "2.0.6",
+              "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+              "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+              "dev": true
+            },
+            "prelude-ls": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+              "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+              "dev": true
+            },
+            "type-check": {
+              "version": "0.3.2",
+              "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+              "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+              "dev": true
+            },
+            "wordwrap": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+              "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+              "dev": true
+            }
+          }
+        },
+        "path-is-inside": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+          "dev": true
+        },
+        "pluralize": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+          "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+          "dev": true
+        },
+        "progress": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+          "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+          "dev": true
+        },
+        "require-uncached": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+          "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+          "dev": true,
+          "dependencies": {
+            "caller-path": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+              "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+              "dev": true,
+              "dependencies": {
+                "callsites": {
+                  "version": "0.2.0",
+                  "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+                  "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+                  "dev": true
+                }
+              }
+            },
+            "resolve-from": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+              "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+              "dev": true
+            }
+          }
+        },
+        "shelljs": {
+          "version": "0.7.7",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
+          "integrity": "sha1-svXHfvlxSPS09uImguELuoZnz/E=",
+          "dev": true,
+          "dependencies": {
+            "interpret": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+              "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
+              "dev": true
+            },
+            "rechoir": {
+              "version": "0.6.2",
+              "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+              "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+              "dev": true,
+              "dependencies": {
+                "resolve": {
+                  "version": "1.3.3",
+                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+                  "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
+                  "dev": true,
+                  "dependencies": {
+                    "path-parse": {
+                      "version": "1.0.5",
+                      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+                      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true
+        },
+        "table": {
+          "version": "3.8.3",
+          "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+          "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+          "dev": true,
+          "dependencies": {
+            "ajv": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+              "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+              "dev": true,
+              "dependencies": {
+                "co": {
+                  "version": "4.6.0",
+                  "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+                  "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+                  "dev": true
+                }
+              }
+            },
+            "ajv-keywords": {
+              "version": "1.5.1",
+              "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+              "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+              "dev": true
+            },
+            "slice-ansi": {
+              "version": "0.0.4",
+              "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+              "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+              "dev": true
+            },
+            "string-width": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
+              "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
+              "dev": true,
+              "dependencies": {
+                "is-fullwidth-code-point": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                  "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                  "dev": true
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                  "dev": true,
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+          "dev": true
+        },
+        "user-home": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+          "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+          "dev": true,
+          "dependencies": {
+            "os-homedir": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "eslint-config-hapi": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-hapi/-/eslint-config-hapi-10.0.0.tgz",
+      "integrity": "sha1-mYCv/XYQPrwf7JK0Vjg0XbGTSPU=",
+      "dev": true
+    },
+    "eslint-plugin-hapi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-hapi/-/eslint-plugin-hapi-4.0.0.tgz",
+      "integrity": "sha1-RKouRfeTmlI5Kc2DK7mqEpqV6CM=",
+      "dev": true
+    },
+    "espree": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
+      "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
+      "dev": true
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    },
+    "extsprintf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+    },
+    "find-rc": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/find-rc/-/find-rc-3.0.1.tgz",
+      "integrity": "sha1-VKQXg3DxC8k3H6jRssKAmir6DM4=",
+      "dev": true
+    },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8="
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fstream": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+        }
+      }
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c="
+    },
+    "gaze": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
+      "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8="
+    },
+    "get-caller-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "glob": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+      "dependencies": {
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
+        }
+      }
+    },
+    "globule": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+      "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
+      "dependencies": {
+        "glob": {
+          "version": "3.1.21",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0="
+        },
+        "inherits": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+          "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js="
+        },
+        "lodash": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+          "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE="
+        }
+      }
+    },
+    "graceful-fs": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+      "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q="
+    },
+    "handlebars": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
+      "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+      "dev": true
+    },
+    "hapi-capitalize-modules": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/hapi-capitalize-modules/-/hapi-capitalize-modules-1.1.6.tgz",
+      "integrity": "sha1-eZEXFBXhXmqjIx5k3ac8gUZmUxg=",
+      "dev": true
+    },
+    "hapi-for-you": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hapi-for-you/-/hapi-for-you-1.0.0.tgz",
+      "integrity": "sha1-02L77o172pwseAHiB+WlzRoLans=",
+      "dev": true
+    },
+    "hapi-scope-start": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/hapi-scope-start/-/hapi-scope-start-2.1.1.tgz",
+      "integrity": "sha1-dJWnJv5yt7yo3izcwdh82M5qtPI=",
+      "dev": true
+    },
+    "har-schema": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
+    },
+    "har-validator": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio="
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+    },
+    "hawk": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+    },
+    "hosted-git-info": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
+      "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc="
+    },
+    "http-signature": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
+    },
+    "indent-string": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ini": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+    },
+    "is-buffer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+      "dev": true
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74="
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko="
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isemail": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
+      "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "items": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/items/-/items-2.1.1.tgz",
+      "integrity": "sha1-i9FtnIOxlSneWuoyGsqtp4NkoZg=",
+      "dev": true
+    },
+    "jodid25519": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+      "optional": true
+    },
+    "joi": {
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-10.5.2.tgz",
+      "integrity": "sha512-Do/NXTokq86nvFfggE4UbwNnyzvALn3Ay+gMwQSAkrQoWTYc4LvkabhypVZiqDZq0TbtVhUpOphe4dmKB6/Pxg==",
+      "dev": true,
+      "dependencies": {
+        "hoek": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.1.1.tgz",
+          "integrity": "sha1-nMVz/7ore0CPtenCoTeWvpTN3Ok=",
+          "dev": true
+        }
+      }
+    },
+    "js-base64": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+      "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4="
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
+    "jsprim": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true
+    },
+    "lab": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/lab/-/lab-13.1.0.tgz",
+      "integrity": "sha1-mD5lfQovDz1ibYBv+OArK89goPY=",
+      "dev": true,
+      "dependencies": {
+        "hoek": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.1.1.tgz",
+          "integrity": "sha1-nMVz/7ore0CPtenCoTeWvpTN3Ok=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "dev": true
+        }
+      }
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true,
+      "optional": true
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU="
+    },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+        }
+      }
+    },
+    "lodash": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8="
+    },
+    "lru-cache": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+      "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4="
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+    },
+    "meow": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs="
+    },
+    "mime-db": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
+    },
+    "mime-types": {
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0="
+    },
+    "minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+      "dependencies": {
+        "lru-cache": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+          "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+        }
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
+      }
+    },
+    "nan": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
+      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
+    },
+    "no-arrowception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/no-arrowception/-/no-arrowception-1.0.0.tgz",
+      "integrity": "sha1-W/PpXrnEG1c4SoBTM9qjtzTuMno=",
+      "dev": true
+    },
+    "node-gyp": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.1.tgz",
+      "integrity": "sha1-GVYQZ/8YVGSt7UeCEmgfR/1XjLw=",
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
+        }
+      }
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k="
+    },
+    "normalize-package-data": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
+      "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs="
+    },
+    "npmconf": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
+      "integrity": "sha1-ZmBqSnNvHnegWaoHGnnJSreBhTo=",
+      "dependencies": {
+        "once": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA="
+        },
+        "semver": {
+          "version": "4.3.6",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
+        }
+      }
+    },
+    "npmlog": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+      "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA=="
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
+        }
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk="
+    },
+    "os-shim": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+      "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc="
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ="
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck="
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+        }
+      }
+    },
+    "performance-now": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o="
+    },
+    "postcss": {
+      "version": "5.2.17",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+      "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                  "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                  "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+            }
+          }
+        },
+        "js-base64": {
+          "version": "2.1.9",
+          "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+          "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4="
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+              "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+            }
+          }
+        }
+      }
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "qs": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+    },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg="
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI="
+    },
+    "readable-stream": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+      "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g="
+    },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94="
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo="
+    },
+    "request": {
+      "version": "2.81.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA="
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
+      "optional": true
+    },
+    "rimraf": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
+        }
+      }
+    },
+    "safe-buffer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+      "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+    },
+    "sass-graph": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
+      "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
+        }
+      }
+    },
+    "scss-tokenizer": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+      "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE="
+    },
+    "seedrandom": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.3.tgz",
+      "integrity": "sha1-JDhQTa0zkXMUv/GKxNeU8W1qrsw=",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "sinon": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
+      "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
+      "dev": true,
+      "dependencies": {
+        "formatio": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+          "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
+          "dev": true
+        },
+        "lolex": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+          "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
+          "dev": true
+        },
+        "samsam": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+          "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
+          "dev": true
+        },
+        "util": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+          "dev": true,
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
+    },
+    "source-map": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s="
+    },
+    "source-map-support": {
+      "version": "0.4.15",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
+      "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
+      "dev": true,
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "dev": true
+        }
+      }
+    },
+    "spawn-sync": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+      "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY="
+    },
+    "spdx-correct": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A="
+    },
+    "spdx-expression-parse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+    },
+    "spdx-license-ids": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+    },
+    "sshpk": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+      "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+      "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg="
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
+    },
+    "strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4="
+    },
+    "strip-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI="
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
+    "tar": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE="
+    },
+    "topo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+      "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+      "dev": true,
+      "dependencies": {
+        "hoek": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.1.1.tgz",
+          "integrity": "sha1-nMVz/7ore0CPtenCoTeWvpTN3Ok=",
+          "dev": true
+        }
+      }
+    },
+    "tough-cookie": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
+    },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "uglify-js": {
+      "version": "2.8.27",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.27.tgz",
+      "integrity": "sha1-R3h/kSsPJC5bmENDvo416V9pTJw=",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+          "dev": true,
+          "optional": true
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "dev": true,
+          "optional": true
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "dev": true,
+          "optional": true
+        },
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true,
+          "optional": true
+        },
+        "yargs": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "dev": true,
+      "optional": true
+    },
+    "uid-number": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
+      "integrity": "sha1-Wj2yPvXb1VuB/ODsmirG/M3ruB4="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+      "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w="
+    },
+    "verror": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
+    },
+    "which": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU="
+    },
+    "which-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+    },
+    "wide-align": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w=="
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "dev": true,
+      "optional": true
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+    },
+    "yargs": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+      "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+      "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "npm run lint && npm run run-tests",
     "lint": "eslint .",
-    "run-tests": "lab -t 82 -e 'development'",
+    "run-tests": "lab -t 85 -e 'development'",
     "test-cov-html": "lab -r html -o coverage.html"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@bigcommerce/stencil-styles",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "Compiles SCSS for the Stencil Framework",
   "main": "lib/index.js",
   "scripts": {
     "test": "npm run lint && npm run run-tests",
     "lint": "eslint .",
-    "run-tests": "lab -t 85 -e 'development'",
+    "run-tests": "lab -t 82 -e 'development'",
     "test-cov-html": "lab -r html -o coverage.html"
   },
   "repository": {
@@ -20,15 +20,15 @@
   },
   "homepage": "https://github.com/bigcommerce/stencil-styles#readme",
   "dependencies": {
-    "@bigcommerce/node-sass": "git://github.com/bigcommerce-labs/node-sass.git#v3.4.3",
+    "@bigcommerce/node-sass": "git://github.com/bigcommerce-labs/node-sass.git#v3.4.4",
     "autoprefixer": "^6.7.3",
     "lodash": "^3.10.1",
     "postcss": "^5.2.14"
   },
   "devDependencies": {
-    "code": "^1.4.0",
+    "code": "^4.0.0",
     "eslint": "^3.15.0",
-    "lab": "^5.5.1",
+    "lab": "^13.1.0",
     "sinon": "^1.14.1"
   }
 }

--- a/test/styles.js
+++ b/test/styles.js
@@ -30,6 +30,7 @@ describe('Stencil-Styles Plugin', () => {
 
         files[osPath('/mock/path1.scss')] = 'color: #fff';
         files[osPath('/mock/path2.scss')] = 'color: #000';
+        files[osPath('/mock/path3.scss')] = 'color: #aaa';
 
         options = {
             files,
@@ -71,33 +72,62 @@ describe('Stencil-Styles Plugin', () => {
     });
 
     describe('compileCss()', () => {
-        let callback;
 
-        beforeEach(done => {
-            callback = sinon.spy();
-            sinon.spy(stencilStyles, 'scssCompiler');
+        describe('when compilations succeed', () => {
+            let callback;
+            beforeEach(done => {
+                callback = sinon.spy();
+                sinon.spy(stencilStyles, 'scssCompiler');
 
-            stencilStyles.compileCss('scss', options, callback);
+                stencilStyles.compileCss('scss', options, callback);
 
-            done();
+                done();
+            });
+
+            it('should call the scss compiler based on the compiler parameter', done => {
+                expect(stencilStyles.scssCompiler.calledOnce).to.equal(true);
+
+                done();
+            });
+
+            it('should call the callback passed in once compilation is complete', done => {
+                expect(callback.calledOnce).to.equal(true);
+
+                done();
+            });
+
+            it('should return error if compilation fails', done => {
+                expect(callback.calledOnce).to.equal(true);
+
+                done();
+            });
+
+            afterEach(done => {
+                stencilStyles.scssCompiler.restore();
+
+                done();
+            });
         });
 
-        it('should call the scss compiler based on the compiler parameter', done => {
-            expect(stencilStyles.scssCompiler.calledOnce).to.equal(true);
 
-            done();
-        });
+        describe('when compilations fails', () => {
+            beforeEach(done => {
+                sinon.stub(Sass, 'render').throws("Error");
+                done();
+            });
 
-        it('should call the callback passed in once compilation is complete', done => {
-            expect(callback.calledOnce).to.equal(true);
+            afterEach(done => {
+                Sass.render.restore();
 
-            done();
-        });
+                done();
+            });
 
-        afterEach(done => {
-            stencilStyles.scssCompiler.restore();
-
-            done();
+            it('should call the scss compiler based on the compiler parameter', done => {
+                stencilStyles.compileCss('scss', options, (err) => {
+                    expect(err).to.be.an.instanceof(Error);
+                    done();
+                });
+            });
         });
     });
 
@@ -261,6 +291,15 @@ describe('Stencil-Styles Plugin', () => {
             expect(result).to.include({ file: 'file1.scss' });
             expect(result).to.include({ contents: 'foo' });
 
+            done();
+        });
+
+        it('should resolve full url', done => {
+            stencilStyles.files[osPath('/foo/bar/file.scss')] = 'foo';
+            stencilStyles.fullUrls[osPath('/foo/file.scss')] = [osPath('/a/prev.scss')];
+
+            const result = stencilStyles.scssImporter(osPath('/bar/file.scss'), osPath('/a/prev.scss'));
+            expect(result.file).to.equal(osPath('/foo/bar/file.scss'));
             done();
         });
     });

--- a/test/styles.js
+++ b/test/styles.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const Code = require('code');
+const Os = require('os');
 const Lab = require('lab');
 const sinon = require('sinon');
 const Sass = require('@bigcommerce/node-sass');
@@ -14,17 +15,22 @@ const expect = Code.expect;
 const it = lab.it;
 
 describe('Stencil-Styles Plugin', () => {
-    var files;
-    var options;
-    var themeSettings;
-    var stencilStyles;
+    let files;
+    let options;
+    let themeSettings;
+    let stencilStyles;
+
+    function osPath(path) {
+        return Os.platform() === 'win32' ? path.replace(/\//g, "\\") : path;
+    }
 
     beforeEach(done => {
         themeSettings = require('./mocks/settings.json');
-        files = {
-            '/mock/path1.scss': 'color: #fff',
-            '/mock/path2.scss': 'color: #000'
-        };
+        files = {};
+
+        files[osPath('/mock/path1.scss')] = 'color: #fff';
+        files[osPath('/mock/path2.scss')] = 'color: #000';
+
         options = {
             files,
             autoprefixerOptions: {},
@@ -65,7 +71,7 @@ describe('Stencil-Styles Plugin', () => {
     });
 
     describe('compileCss()', () => {
-        var callback;
+        let callback;
 
         beforeEach(done => {
             callback = sinon.spy();
@@ -97,7 +103,7 @@ describe('Stencil-Styles Plugin', () => {
 
     describe('scssFunctions', () => {
         it('should return an array with all required functions', done => {
-            var result = stencilStyles.scssFunctions(themeSettings);
+            const result = stencilStyles.scssFunctions(themeSettings);
 
             expect(result).to.be.an.object();
             expect(_.keys(result)).to.contain([
@@ -106,14 +112,14 @@ describe('Stencil-Styles Plugin', () => {
                 'stencilString($name)',
                 'stencilImage($image, $size)',
                 'stencilFontFamily($name)',
-                'stencilFontWeight($name)'
+                'stencilFontWeight($name)',
             ]);
 
             done();
         });
 
         describe('stencilNumber', () => {
-            var stencilNumber;
+            let stencilNumber;
 
             beforeEach(done => {
                 stencilNumber = stencilStyles.scssFunctions(themeSettings)['stencilNumber($name, $unit: px)'];
@@ -122,8 +128,8 @@ describe('Stencil-Styles Plugin', () => {
             });
 
             it('should return the expected number and unit value', done => {
-                var settingName = new Sass.types.String('google-font-size'),
-                    unit = new Sass.types.String('em');
+                const settingName = new Sass.types.String('google-font-size');
+                const unit = new Sass.types.String('em');
 
                 expect(stencilNumber(settingName, unit).getValue()).to.equal(14);
                 expect(stencilNumber(settingName, unit).getUnit()).to.equal('em');
@@ -132,8 +138,8 @@ describe('Stencil-Styles Plugin', () => {
             });
 
             it('should return 0 if passed a wrong setting name', done => {
-                var settingName = new Sass.types.String('wrong-setting'),
-                    unit = new Sass.types.String('px');
+                const settingName = new Sass.types.String('wrong-setting');
+                const unit = new Sass.types.String('px');
 
                 expect(stencilNumber(settingName, unit).getValue()).to.equal(0);
 
@@ -141,8 +147,8 @@ describe('Stencil-Styles Plugin', () => {
             });
 
             it('should return 0 if passed a wrong setting value', done => {
-                var settingName = new Sass.types.String('google-font-wrong-size'),
-                    unit = new Sass.types.String('px');
+                const settingName = new Sass.types.String('google-font-wrong-size');
+                const unit = new Sass.types.String('px');
 
                 expect(stencilNumber(settingName, unit).getValue()).to.equal(0);
 
@@ -150,8 +156,8 @@ describe('Stencil-Styles Plugin', () => {
             });
 
             it('should return a Sass.types.Number', done => {
-                var settingName = new Sass.types.String('google-font-size'),
-                    unit = new Sass.types.String('px');
+                const settingName = new Sass.types.String('google-font-size');
+                const unit = new Sass.types.String('px');
 
                 expect(stencilNumber(settingName, unit) instanceof Sass.types.Number).to.equal(true);
 
@@ -160,7 +166,7 @@ describe('Stencil-Styles Plugin', () => {
         });
 
         describe('stencilImage', () => {
-            var stencilImage;
+            let stencilImage;
 
             beforeEach(done => {
                 stencilImage = stencilStyles.scssFunctions(themeSettings)['stencilImage($image, $size)'];
@@ -169,8 +175,8 @@ describe('Stencil-Styles Plugin', () => {
             });
 
             it('should return the expected string value', done => {
-                var image = new Sass.types.String('img-url'),
-                    size = new Sass.types.String('img-size');
+                const image = new Sass.types.String('img-url');
+                const size = new Sass.types.String('img-size');
 
                 expect(stencilImage(image, size).getValue()).to.equal('stencil/1000x400/example.jpg');
 
@@ -178,8 +184,8 @@ describe('Stencil-Styles Plugin', () => {
             });
 
             it('should return null if passed an empty image url value', done => {
-                var image = new Sass.types.String('img-url-empty'),
-                    size = new Sass.types.String('img-size');
+                const image = new Sass.types.String('img-url-empty');
+                const size = new Sass.types.String('img-size');
 
                 expect(stencilImage(image, size)).to.equal(Sass.NULL);
 
@@ -187,8 +193,8 @@ describe('Stencil-Styles Plugin', () => {
             });
 
             it('should return null if passed a wrong image url value', done => {
-                var image = new Sass.types.String('img-url-wrong--format'),
-                    size = new Sass.types.String('img-size');
+                const image = new Sass.types.String('img-url-wrong--format');
+                const size = new Sass.types.String('img-size');
 
                 expect(stencilImage(image, size)).to.equal(Sass.NULL);
 
@@ -196,8 +202,8 @@ describe('Stencil-Styles Plugin', () => {
             });
 
             it('should return null if passed a wrong image dimension value', done => {
-                var image = new Sass.types.String('img-url'),
-                    size = new Sass.types.String('img-size-wrong--format');
+                const image = new Sass.types.String('img-url');
+                const size = new Sass.types.String('img-size-wrong--format');
 
                 expect(stencilImage(image, size)).to.equal(Sass.NULL);
 
@@ -205,8 +211,8 @@ describe('Stencil-Styles Plugin', () => {
             });
 
             it('should return a Sass.types.String', done => {
-                var image = new Sass.types.String('img-url'),
-                    size = new Sass.types.String('img-size');
+                const image = new Sass.types.String('img-url');
+                const size = new Sass.types.String('img-size');
 
                 expect(stencilImage(image, size) instanceof Sass.types.String).to.equal(true);
 
@@ -217,21 +223,43 @@ describe('Stencil-Styles Plugin', () => {
 
     describe('scssImporter()', () => {
         it('should return an error if files do not exist', done => {
-            var result = stencilStyles.scssImporter('/path2', 'other/path1.scss');
+            const result = stencilStyles.scssImporter('/path2', 'other/path1.scss');
 
             expect(result.constructor).to.equal(Error);
-            expect(result.message).to.equal("other/path2.scss doesn't exist!");
+            expect(result.message).to.include("doesn't exist!");
 
             done();
         });
 
         it('should return an object with a file name and content', done => {
             stencilStyles.files = options.files;
-            var result = stencilStyles.scssImporter('/path2', '/mock/path1.scss');
+            const result = stencilStyles.scssImporter(osPath('/path2'), osPath('/mock/path1.scss'));
 
             expect(result).to.be.an.object();
-            expect(result).to.include({ file: '/mock/path2.scss' });
-            expect(result).to.include({ contents: files['/mock/path2.scss'] });
+            expect(result).to.include({ file: osPath('/mock/path2.scss') });
+            expect(result).to.include({ contents: files[osPath('/mock/path2.scss')] });
+
+            done();
+        });
+
+        it('should succeed when the extension is passed', done => {
+            stencilStyles.files = options.files;
+            const result = stencilStyles.scssImporter(osPath('/path2'), osPath('/mock/path1.scss'));
+
+            expect(result).to.be.an.object();
+            expect(result).to.include({ file: osPath('/mock/path2.scss') });
+            expect(result).to.include({ contents: files[osPath('/mock/path2.scss')] });
+
+            done();
+        });
+
+        it('should succeed when ran from the root path (prev=stdin)', done => {
+            stencilStyles.files = { "file1.scss": 'foo' };
+            const result = stencilStyles.scssImporter('file1', 'stdin');
+
+            expect(result).to.be.an.object();
+            expect(result).to.include({ file: 'file1.scss' });
+            expect(result).to.include({ contents: 'foo' });
 
             done();
         });
@@ -276,7 +304,7 @@ describe('Stencil-Styles Plugin', () => {
             done();
         });
 
-        var googleFont = 'Google_Open+Sans_400';
+        const googleFont = 'Google_Open+Sans_400';
 
         it('should remove the Google_ from the value and call defaultParser', done => {
             stencilStyles.googleFontParser(googleFont, 'family');
@@ -294,10 +322,10 @@ describe('Stencil-Styles Plugin', () => {
     });
 
     describe('defaultFontParser()', () => {
-        var nativeFont = 'Times New Roman_400';
+        const nativeFont = 'Times New Roman_400';
 
         it('should return the font family name', done => {
-            var result = stencilStyles.defaultFontParser(nativeFont, 'family');
+            const result = stencilStyles.defaultFontParser(nativeFont, 'family');
 
             expect(result.getValue()).to.equal('"Times New Roman"');
 
@@ -305,7 +333,7 @@ describe('Stencil-Styles Plugin', () => {
         });
 
         it('should return the font weight', done => {
-            var result = stencilStyles.defaultFontParser(nativeFont, 'weight');
+            const result = stencilStyles.defaultFontParser(nativeFont, 'weight');
 
             expect(result.getValue()).to.equal('400');
 
@@ -313,7 +341,7 @@ describe('Stencil-Styles Plugin', () => {
         });
 
         it('should return the first font weight if multiple are defined', done => {
-            var result = stencilStyles.defaultFontParser('Times New Roman_400,700,800', 'weight');
+            const result = stencilStyles.defaultFontParser('Times New Roman_400,700,800', 'weight');
 
             expect(result.getValue()).to.equal('400');
 
@@ -321,7 +349,7 @@ describe('Stencil-Styles Plugin', () => {
         });
 
         it('should return a typeof Sass.NULL if family / weight is empty', done => {
-            var result = stencilStyles.defaultFontParser(undefined, 'family');
+            const result = stencilStyles.defaultFontParser(undefined, 'family');
 
             expect(result instanceof Sass.types.Null).to.equal(true);
 


### PR DESCRIPTION
- node-sass version bump compatible with Node.js 8
- Added AppVeyor to run tests on Windows
- Run tests on Node 4, 5, 6, 7 & 8
- Fix a bug in `scssImporter` that was happening on Windows + tests

@bigcommerce/stencil-team 