### PR TITLE
Custom SASS function: stencilWebDAV

### DIFF
--- a/lib/styles.js
+++ b/lib/styles.js
@@ -5,6 +5,7 @@ const autoprefixer = require('autoprefixer');
 const postcss = require('postcss');
 const path = require('path');
 const sass = require('@bigcommerce/node-sass');
+const url = require('url');
 
 function StencilStyles() {
     this.files = {};
@@ -162,11 +163,13 @@ function StencilStyles() {
         };
 
         sassFunctions['stencilWebDAV($asset)'] = (assetObj) => {
-            const url = typeof cdnUrl === 'string' ? cdnUrl : '';
             const assetPath = assetObj.getValue();
             const asset = typeof assetPath === 'string' ? assetPath : '';
+            const baseUrl = typeof cdnUrl === 'string' ? cdnUrl : '';
+            let pathname = url.parse(baseUrl).pathname;
+            pathname = typeof pathname === 'string' ? pathname : '';
 
-            return new sass.types.String(path.join(url, '/content', asset));
+            return new sass.types.String(url.resolve(baseUrl, path.join('/', pathname, 'content', asset)));
         };
 
         return sassFunctions;

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -24,7 +24,7 @@ function StencilStyles() {
                 data: options.data,
                 dest: options.dest,
                 sourceMap: options.sourceMap,
-                functions: this.scssFunctions(options.themeSettings),
+                functions: this.scssFunctions(options.themeSettings, options.cdnUrl),
             };
 
             this.files = options.files || {};
@@ -85,12 +85,13 @@ function StencilStyles() {
     };
 
     /**
-     * Generate sass helper functions with access to theme settings
+     * Generate sass helper functions with access to theme settings and CDN URL
      *
      * @param themeSettings
+     * @param cdnUrl
      * @returns object
      */
-    this.scssFunctions = (themeSettings) => {
+    this.scssFunctions = (themeSettings, cdnUrl) => {
         const sassFunctions = {};
 
         sassFunctions['stencilNumber($name, $unit: px)'] = (nameObj, unitObj) => {
@@ -158,6 +159,14 @@ function StencilStyles() {
 
         sassFunctions['stencilFontWeight($name)'] = (nameObj) => {
             return this.stencilFont(themeSettings[nameObj.getValue()], 'weight');
+        };
+
+        sassFunctions['stencilWebDAV($asset)'] = (assetObj) => {
+            const url = typeof cdnUrl === 'string' ? cdnUrl : '';
+            const assetPath = assetObj.getValue();
+            const asset = typeof assetPath === 'string' ? assetPath : '';
+
+            return new sass.types.String(path.join(url, '/content', asset));
         };
 
         return sassFunctions;

--- a/test/styles.js
+++ b/test/styles.js
@@ -143,6 +143,7 @@ describe('Stencil-Styles Plugin', () => {
                 'stencilImage($image, $size)',
                 'stencilFontFamily($name)',
                 'stencilFontWeight($name)',
+                'stencilWebDAV($asset)',
             ]);
 
             done();
@@ -245,6 +246,33 @@ describe('Stencil-Styles Plugin', () => {
                 const size = new Sass.types.String('img-size');
 
                 expect(stencilImage(image, size) instanceof Sass.types.String).to.equal(true);
+
+                done();
+            });
+        });
+
+        describe('stencilWebDAV', () => {
+            let stencilWebDAV;
+            const cdnUrl = 'https://cdn7.bigcommerce.com/wl3b9dt0cd';
+
+            beforeEach(done => {
+                stencilWebDAV = stencilStyles.scssFunctions(themeSettings, cdnUrl)['stencilWebDAV($asset)'];
+
+                done();
+            });
+
+            it('should return the expected string value', done => {
+                const asset = new Sass.types.String('img/image.jpg');
+
+                expect(stencilWebDAV(asset).getValue()).to.equal('https://cdn7.bigcommerce.com/wl3b9dt0cd/content/img/image.jpg');
+
+                done();
+            });
+
+            it('should return a Sass.types.String', done => {
+                const asset = new Sass.types.String('img/image.jpg');
+
+                expect(stencilWebDAV(asset) instanceof Sass.types.String).to.equal(true);
 
                 done();
             });

--- a/test/styles.js
+++ b/test/styles.js
@@ -52,8 +52,8 @@ describe('Stencil-Styles Plugin', () => {
 
     describe('autoPrefix', () => {
         it('should add vendor prefixes to css rules', done => {
-            const prefixedCss = stencilStyles.autoPrefix('a { transform: scale(0.5); }', {});
-            expect(prefixedCss).to.contain(['-webkit-transform']);
+            const prefixedCss = stencilStyles.autoPrefix('a { user-select: none; }', {});
+            expect(prefixedCss).to.contain(['-webkit-user-select']);
             done();
         });
 


### PR DESCRIPTION
When we move theme assets to WebDAV, we can access them from HTML templates by using the Handlebars helper as described in Stencil documentation:

```html
<img src="{{cdn "webdav:img/image.jpg"}}">
```

Source: https://stencil.bigcommerce.com/docs/webdav-static-assets#restructure

The Handlebars helper treats `/content/` as the default/root WebDAV directory. This is good. :+1: 

<hr>

Unfortunately, there is no reliable way to achieve the same result from SCSS stylesheets. There is no support for using images at WebDAV as `background-image`.

This Pull Request introduces a `stencilWebDAV` custom SASS function, to perform the very same feature that we already have within the HTML templates, as referred above. Its usage is similar to the already existent `stencilImage` custom SASS function:

```scss
body {
  background-image: url(stencilWebDAV('img/image.jpg'));
}
```

<hr>

The Pull Request here is small and straightforward, and it is all which is needed to support the feature at `stencil-styles`.

It works out of the box for **local development** using `stencil start`, because an empty `cdnUrl` will result in a `/content/img/image.jpg`, which is properly proxied by the Stencil local server.

But... at **server-side**, it requires that `stencilStyles.compileCss` **caller** provides the `cdnUrl` value.

I do not know and I do not have access to the server-side internals.

But, as a proof-of-concept, I have created a `stencil-cli` branch, making it obtain the `cdnUrl` and pass it as an option in the `stencilStyles.compileCss` call.

It works! In my local development, I have the `stencilWebDAV` custom SASS function providing the full CDN URL for assets in WebDAV, including the CDN base URL for the store, with protocol and domain.

I have created a PR for this proof-of-concept `stencil-cli` branch: https://github.com/bigcommerce/stencil-cli/pull/385
