### PR TITLE
MERC-5746: adds nested key to stencil helpers

### DIFF
--- a/lib/styles.js
+++ b/lib/styles.js
@@ -94,70 +94,52 @@ function StencilStyles() {
         const sassFunctions = {};
 
         sassFunctions['stencilNumber($name, $unit: px)'] = (nameObj, unitObj) => {
-            const name = nameObj.getValue();
+            const name = _.get(themeSettings, nameObj.getValue());
             const unit = unitObj.getValue();
-            var value = 0;
-
-            if (themeSettings[name]) {
-                value = parseFloat(themeSettings[name]);
-            }
-
-            if (_.isNaN(value)) {
-                value = 0;
-            }
+            const value = parseFloat(name) || 0;
 
             return new sass.types.Number(value, unit);
         };
 
         sassFunctions['stencilColor($name)'] = (nameObj) => {
-            const name = nameObj.getValue();
-            var val;
-            var ret;
+            const name = _.get(themeSettings, nameObj.getValue());
+            const val = name && name[0] === '#' ? name.substr(1) : name;
 
-            if (themeSettings[name]) {
-                val = themeSettings[name];
-
-                if (val[0] === '#') {
-                    val = val.substr(1);
-                }
-
-                ret = new sass.types.Color(parseInt('0xff' + val, 16));
-            } else {
-                ret = sass.NULL;
-            }
-
-            return ret;
+            return name
+                ? new sass.types.Color(parseInt('0xff' + val, 16))
+                : sass.NULL;
         };
 
         sassFunctions['stencilString($name)'] = (nameObj) => {
-            const name = nameObj.getValue();
+            const name = _.get(themeSettings, nameObj.getValue());
 
-            return themeSettings[name]
-                ? new sass.types.String(themeSettings[name])
+            return name
+                ? new sass.types.String(name)
                 : sass.NULL;
         };
 
         sassFunctions['stencilImage($image, $size)'] = (imageObj, sizeObj) => {
             const sizeRegex = /^\d+x\d+$/g;
-            const image = imageObj.getValue();
-            const size = sizeObj.getValue();
-            var ret;
+            const image = _.get(themeSettings, imageObj.getValue());
+            const size = _.get(themeSettings, sizeObj.getValue());
 
-            if (themeSettings[image].indexOf('{:size}') !== -1 && sizeRegex.test(themeSettings[size])) {
-                ret = new sass.types.String(themeSettings[image].replace('{:size}', themeSettings[size]));
+            if (image.indexOf('{:size}') !== -1 && sizeRegex.test(size)) {
+                return new sass.types.String(image.replace('{:size}', size));
             } else {
-                ret = sass.NULL;
+                return sass.NULL;
             }
-
-            return ret;
         };
 
         sassFunctions['stencilFontFamily($name)'] = (nameObj) => {
-            return this.stencilFont(themeSettings[nameObj.getValue()], 'family');
+            const name = _.get(themeSettings, nameObj.getValue());
+
+            return this.stencilFont(name, 'family');
         };
 
         sassFunctions['stencilFontWeight($name)'] = (nameObj) => {
-            return this.stencilFont(themeSettings[nameObj.getValue()], 'weight');
+            const name = _.get(themeSettings, nameObj.getValue());
+
+            return this.stencilFont(name, 'weight');
         };
 
         return sassFunctions;

--- a/test/mocks/settings.json
+++ b/test/mocks/settings.json
@@ -1,11 +1,20 @@
 {
   "native-font": "Times New Roman_400",
   "google-font": "Google_Open+Sans_400",
+  "google-font-color": "#000000",
   "google-font-size": 14,
   "google-font-wrong-size": "Not a Number",
   "img-url": "stencil/{:size}/example.jpg",
   "img-url-empty": "",
   "img-url-wrong--format": "stencil/example.jpg",
   "img-size": "1000x400",
-  "img-size-wrong--format": "1000400"
+  "img-size-wrong--format": "1000400",
+  "global": {
+    "h1": {
+      "font-color": "#FFFFFF",
+      "font-size": {
+        "value": 16
+      }
+    }
+  }
 }

--- a/test/styles.js
+++ b/test/styles.js
@@ -158,12 +158,22 @@ describe('Stencil-Styles Plugin', () => {
                 done();
             });
 
-            it('should return the expected number and unit value', done => {
+            it('should return the expected for flat key', done => {
                 const settingName = new Sass.types.String('google-font-size');
                 const unit = new Sass.types.String('em');
 
                 expect(stencilNumber(settingName, unit).getValue()).to.equal(14);
                 expect(stencilNumber(settingName, unit).getUnit()).to.equal('em');
+
+                done();
+            });
+
+            it('should return the expected for nested key', done => {
+                const settingName = new Sass.types.String('global.h1.font-size.value');
+                const unit = new Sass.types.String('rem');
+
+                expect(stencilNumber(settingName, unit).getValue()).to.equal(16);
+                expect(stencilNumber(settingName, unit).getUnit()).to.equal('rem');
 
                 done();
             });


### PR DESCRIPTION
## What?
Adds ability to get nested themeSettings values from the provided key.

## Why?
[MERC-5746](https://jira.bigcommerce.com/browse/MERC-5746).  New Global Styles feature uses a nested object and we need to be able to retrieve those values in order to properly compute the SASS/ CSS.

@bigcommerce/merc-team