### PR TITLE
Reduce npm package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,11 @@
     "url": "https://github.com/bigcommerce/stencil-styles/issues"
   },
   "homepage": "https://github.com/bigcommerce/stencil-styles#readme",
+  "files": [
+    "LICENSE",
+    "README.md",
+    "lib/"
+  ],
   "dependencies": {
     "@bigcommerce/node-sass": "git://github.com/bigcommerce-labs/node-sass.git#v3.5.0",
     "autoprefixer": "^6.7.3",


### PR DESCRIPTION
Reduce npm package size

### Before
```
npm notice package size:  15.7 kB
npm notice unpacked size: 156.4 kB
```
```
$ npm pack && tar -xvzf *.tgz && rm -rf package *.tgz
npm notice
npm notice 📦  @bigcommerce/stencil-styles@1.2.1
npm notice === Tarball Contents ===
npm notice 1.2kB   package.json
npm notice 413B    .eslintrc
npm notice 97B     .travis.yml
npm notice 281B    appveyor.yml
npm notice 128.8kB coverage.html
npm notice 1.6kB   LICENSE
npm notice 2.5kB   README.md
npm notice 355B    lib/index.js
npm notice 8.3kB   lib/styles.js
npm notice 487B    test/mocks/settings.json
npm notice 12.5kB  test/styles.js
npm notice === Tarball Details ===
npm notice name:          @bigcommerce/stencil-styles
npm notice version:       1.2.1
npm notice filename:      bigcommerce-stencil-styles-1.2.1.tgz
npm notice package size:  15.7 kB
npm notice unpacked size: 156.4 kB
npm notice shasum:        9447bb529941e4b83ca6136c0414ae48738ddabd
npm notice integrity:     sha512-O9I2gVIpb5X7u[...]9b6Z5BNluEQSg==
npm notice total files:   11
npm notice
bigcommerce-stencil-styles-1.2.1.tgz
x package/package.json
x package/.eslintrc
x package/.travis.yml
x package/appveyor.yml
x package/coverage.html
x package/LICENSE
x package/README.md
x package/lib/index.js
x package/lib/styles.js
x package/test/mocks/settings.json
x package/test/styles.js
```

### After
```
npm notice package size:  4.3 kB
npm notice unpacked size: 14.0 kB
```
```
$ npm pack && tar -xvzf *.tgz && rm -rf package *.tgz
npm notice
npm notice 📦  @bigcommerce/stencil-styles@1.2.1
npm notice === Tarball Contents ===
npm notice 1.2kB package.json
npm notice 1.6kB LICENSE
npm notice 2.5kB README.md
npm notice 355B  lib/index.js
npm notice 8.3kB lib/styles.js
npm notice === Tarball Details ===
npm notice name:          @bigcommerce/stencil-styles
npm notice version:       1.2.1
npm notice filename:      bigcommerce-stencil-styles-1.2.1.tgz
npm notice package size:  4.3 kB
npm notice unpacked size: 14.0 kB
npm notice shasum:        9cd85bba51ccb790d2e815138e4c1051fbf4b179
npm notice integrity:     sha512-pV8x87Fs0LLU8[...]G69RP18aD697Q==
npm notice total files:   5
npm notice
bigcommerce-stencil-styles-1.2.1.tgz
x package/package.json
x package/LICENSE
x package/README.md
x package/lib/index.js
x package/lib/styles.js
```

@bigcommerce/storefront-team 