### PR TITLE
Remove files after the compilation is finished

### DIFF
--- a/lib/styles.js
+++ b/lib/styles.js
@@ -29,6 +29,7 @@ function StencilStyles() {
 
             this.files = options.files || {};
             this.scssCompiler(compilerOptions, (err, css) => {
+                this.files = {};
                 if (err) {
                     return callback(err);
                 }


### PR DESCRIPTION
Stencil Styles is not flushing files exactly after the request. They're being overridden on the next request.

I don't think it will fix a memory leak, but will surely affect as much efficient memory allocation