### PR TITLE
STRF-8583 run bigcommerce fork and origin master of node sass in the same process

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,13 +1,14 @@
 {
   "parserOptions": {
-    "ecmaVersion": 6,
-    "sourceType": "module"
+    "ecmaVersion": 2018, // suppport syntax features (like Object spread operator) up to es2018
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "impliedStrict": true
+    }
   },
   "env": {
+    "es2017": true, // suppport globals (like Promise) up to es2017 (es2018 doesn't have new globals)
     "node": true
-  },
-  "globals": {
-
   },
   "rules": {
     "curly": 2,

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-  - 8
   - 10
   - 12
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,6 @@ environment:
   matrix:
     - nodejs_version: "12"
     - nodejs_version: "10"
-    - nodejs_version: "8"
 
 platform:
   - x86

--- a/lib/ScssCompiler.js
+++ b/lib/ScssCompiler.js
@@ -1,0 +1,301 @@
+const _ = require('lodash');
+const path = require('path');
+const nodeSassFork = require('@bigcommerce/node-sass');
+const dartSass = require('sass');
+const Fiber = require('fibers');
+const { promisify } = require('util');
+
+class ScssCompiler {
+    /**
+     * @param {object} logger
+     * @param {function} logger.error
+     * @param {object} [engines]
+     * @param {object} engines.primary
+     * @param {object} engines.fallback
+     */
+    constructor(
+        logger,
+        engines = {
+            primary: dartSass,
+            fallback: nodeSassFork,
+        },
+    ) {
+        this.logger = logger;
+        this.engines = engines;
+        this.files = {};
+        this.fullUrls = {};
+        this._wasUsed = false;
+
+        this.activatePrimaryEngine();
+    }
+
+    activatePrimaryEngine() {
+        this.engines.active = this.engines.primary;
+    }
+
+    activateFallbackEngine() {
+        this.engines.active = this.engines.fallback;
+    }
+
+    get saasTypes() {
+        return this.engines.active.types;
+    }
+
+    /**
+     * We need to make sure to create a new instance per each compilation to avoid processes interfering each other (e.g. sharing this.files)
+     *
+     * @private
+     */
+    _assertOneOffUsage() {
+        if (this._wasUsed) {
+            throw new Error('This ScssCompiler instance was already used. Please, create a new instance per compilation')
+        } else {
+            this._wasUsed = true;
+        }
+    }
+
+    /**
+     * Compile SCSS into CSS and return the content
+     *
+     * @public
+     * @param options
+     */
+    async compile(options) {
+        this._assertOneOffUsage();
+
+        this.files = options.files || {};
+        const engineOptions = {
+            data: options.data,
+            outFile: options.dest,
+            files: options.files,
+            sourceMap: options.sourceMap,
+            sourceMapEmbed: options.sourceMap,
+            fiber: Fiber,
+            functions: this.getScssFunctions(options.themeSettings),
+            importer: this.scssImporter.bind(this),
+        };
+        let result = {};
+        try {
+            result = await this._render(engineOptions);
+        } catch (primaryEngineErr) {
+            this.logger.error(
+                `Error during css compilation by the primary engine:\n`
+                + primaryEngineErr +
+                `\nWill retry with a fallback engine`,
+            );
+            this.activateFallbackEngine();
+            result = await this._render(engineOptions);
+        }
+
+        return result.css;
+    }
+
+    /**
+     * Calls active engine with the specified options
+     *
+     * @private
+     * @param options
+     * @return {Promise<object>}
+     */
+    async _render(options) {
+        return promisify(this.engines.active.render)(options);
+    }
+
+    /**
+     * Generate sass helper functions with access to theme settings
+     *
+     * @private
+     * @param themeSettings
+     * @returns object
+     */
+    getScssFunctions(themeSettings) {
+        const sassFunctions = {};
+
+        sassFunctions['stencilNumber($name, $unit: px)'] = (nameObj, unitObj) => {
+            const name = _.get(themeSettings, nameObj.getValue());
+            const unit = unitObj.getValue();
+            const value = parseFloat(name) || 0;
+
+            return new this.saasTypes.Number(value, unit);
+        };
+
+        sassFunctions['stencilColor($name)'] = (nameObj) => {
+            const name = _.get(themeSettings, nameObj.getValue());
+            const val = name && name[0] === '#' ? name.substr(1) : name;
+
+            return name
+                ? new this.saasTypes.Color(parseInt('0xff' + val, 16))
+                : this.saasTypes.Null.NULL;
+        };
+
+        sassFunctions['stencilString($name)'] = (nameObj) => {
+            const name = _.get(themeSettings, nameObj.getValue());
+
+            return name
+                ? new this.saasTypes.String(name)
+                : this.saasTypes.Null.NULL;
+        };
+
+        sassFunctions['stencilImage($image, $size)'] = (imageObj, sizeObj) => {
+            const sizeRegex = /^\d+x\d+$/g;
+            const image = _.get(themeSettings, imageObj.getValue());
+            const size = _.get(themeSettings, sizeObj.getValue());
+
+            if (image.indexOf('{:size}') !== -1 && sizeRegex.test(size)) {
+                return new this.saasTypes.String(image.replace('{:size}', size));
+            } else {
+                return this.saasTypes.Null.NULL;
+            }
+        };
+
+        sassFunctions['stencilFontFamily($name)'] = (nameObj) => {
+            const name = _.get(themeSettings, nameObj.getValue());
+
+            return this.stencilFont(name, 'family');
+        };
+
+        sassFunctions['stencilFontWeight($name)'] = (nameObj) => {
+            const name = _.get(themeSettings, nameObj.getValue());
+
+            return this.stencilFont(name, 'weight');
+        };
+
+        return sassFunctions;
+    }
+
+    /**
+     * The custom importer callback function to pass to the node-sass compiler
+     *
+     * @private
+     * @param url
+     * @param prev
+     * @returns object
+     */
+    scssImporter(url, prev) {
+        let fullUrl = url + (url.match(/.*\.scss$/) ? '' : '.scss');
+
+        if (prev !== 'stdin') {
+            fullUrl = path.join(path.parse(prev).dir, fullUrl);
+        }
+
+        if (this.files[fullUrl] === undefined) {
+            const possiblePaths = Object.keys(_.pickBy(this.fullUrls, val => val.indexOf(prev) !== -1));
+
+            possiblePaths.find(possiblePath => {
+                const possibleFullUrl = path.join(path.parse(possiblePath).dir, url);
+
+                if (this.files[possibleFullUrl] !== undefined) {
+                    fullUrl = possibleFullUrl;
+
+                    // We found it so lets kick out of the loop
+                    return true;
+                }
+            });
+        }
+
+        if (this.files[fullUrl] === undefined) {
+            return new Error(fullUrl + ' doesn\'t exist!');
+        }
+
+        if (!this.fullUrls[fullUrl]) {
+            this.fullUrls[fullUrl] = [url];
+        } else if (this.fullUrls[fullUrl].indexOf(url) === -1) {
+            this.fullUrls[fullUrl].push(url);
+        }
+
+        return {
+            file: fullUrl,
+            contents: this.files[fullUrl],
+        };
+    }
+
+    /**
+     * Calls the appropriate font parser for a given provider (Google, etc.)
+     *
+     * @private
+     * @param value
+     * @param type
+     * @returns string or null
+     */
+    stencilFont(value, type) {
+        const provider = value.split('_')[0];
+
+        switch (provider) {
+        case 'Google':
+            return this.googleFontParser(value, type);
+        default:
+            return this.defaultFontParser(value, type);
+        }
+    }
+
+    /**
+     * Removes "Google_" from the value and calls the default parser
+     * Expects the value in the config has a family_weight structure.
+     * Eg value: "Google_Open+Sans_700", "Google_Open+Sans", "Google_Open+Sans_400_sans", "Google_Open+Sans_400,700_sans"
+     *
+     * @private
+     * @param value
+     * @param type - 'family' or 'weight'
+     * @returns {*}
+     */
+    googleFontParser(value, type) {
+        // Splitting the value
+        // Eg: 'Google_Open+Sans_700' -> [Google, Open+Sans, 700]
+        value = value.split('_');
+
+        // Removing the Google value
+        // Eg: [Google, Open+Sans, 700] -> [Open+Sans, 700]
+        value = value.splice(1);
+
+        // Join the value again
+        // Eg: [Open+Sans, 700] -> 'Open+Sans_700'
+        value = value.join('_');
+
+        return this.defaultFontParser(value, type);
+    }
+
+    /**
+     * Returns the font family or weight
+     * Expects the value to have a family_weight structure.
+     * Will convert + to spaces
+     * Eg value: "Open+Sans_700", "Open Sans", "Open+Sans_400_sans", "Open+Sans_400,700_sans"
+     *
+     * @private
+     * @param value
+     * @param type - 'family' or 'weight'
+     * @returns {*}
+     */
+    defaultFontParser(value, type) {
+        const typeFamily = type === 'family';
+        const index = typeFamily ? 0 : 1;
+        let formattedString;
+        let split;
+
+        if (!_.isString(value)) {
+            return this.saasTypes.Null.NULL;
+        }
+
+        split = value.split('_');
+
+        if (_.isEmpty(split[index])) {
+            return this.saasTypes.Null.NULL;
+        }
+
+        formattedString = split[index].split(',')[0];
+        formattedString = formattedString.replace(/\+/g, ' ');
+
+        // Make sure the string has no quotes in it
+        formattedString = formattedString.replace(/'|"/g, '');
+
+        if (typeFamily) {
+            // Wrap the string in quotes since Sass type String
+            // works with quotes and without quotes (it won't add them)
+            // and we end up with font-family: Open Sans with no quotes
+            formattedString = '"' + formattedString + '"';
+        }
+
+        return new this.saasTypes.String(formattedString);
+    }
+}
+
+module.exports = ScssCompiler;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,16 +1,3 @@
 const StencilStyles = require('./styles');
 
 module.exports = StencilStyles;
-
-module.exports.register = function (server, options, next) {
-    var stencilStyles = new StencilStyles();
-
-    server.expose('compile', stencilStyles.compileCss);
-
-    return next();
-};
-
-module.exports.register.attributes = {
-    name: 'StencilStyles',
-    version: '0.0.1',
-};

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -1,57 +1,37 @@
-'use strict';
-
-const _ = require('lodash');
 const autoprefixer = require('autoprefixer');
 const postcss = require('postcss');
-const path = require('path');
-const nodeSassFork = require('@bigcommerce/node-sass');
-const dartSass = require('sass');
-const Fiber = require('fibers');
-const { promisify } = require('util');
+const ScssCompiler = require("./ScssCompiler");
 
-function StencilStyles() {
-    this.files = {};
-    this.fullUrls = {};
-
-    this.compilers = {
-        active: null,
-        scss: {
-            primary: dartSass,
-            fallback: nodeSassFork,
+class StencilStyles {
+    /**
+     * @param {object} logger
+     * @param compilers
+     */
+    constructor(
+        logger = console,
+        compilers = {
+            scss: new ScssCompiler(logger),
         },
+    ) {
+        this.logger = logger;
+        this.compilers = compilers;
     }
 
     /**
-     * Compiles the CSS based on which compiler has been specified
+     * Calls a compiler for the specified syntax and then processes the output with autoprefixer
      *
-     * @param syntax
-     * @param options
-     * @param callback
+     * @param {string} syntax
+     * @param {object} options
      */
-    this.compileCss = (syntax, options, callback) => {
-        switch(syntax) {
-        case 'scss':
-            const compilerOptions = {
-                data: options.data,
-                dest: options.dest,
-                sourceMap: options.sourceMap,
-                functions: this.scssFunctions(options.themeSettings),
-            };
-
-            this.files = options.files || {};
-            this.compileScss(compilerOptions, (err, css) => {
-                this.files = {};
-                if (err) {
-                    return callback(err);
-                }
-
-                callback(null, this.autoPrefix(css, options.autoprefixerOptions));
-            });
-            break;
+    async compileCss(syntax, { autoprefixerOptions, ...compilerOptions }) {
+        const compiler = this.compilers[syntax];
+        if (compiler) {
+            const css = await compiler.compile(compilerOptions);
+            return this.autoPrefix(css, autoprefixerOptions)
         }
-    };
+    }
 
-    this.autoPrefix = (css, autoprefixerOptions) => {
+    autoPrefix(css, autoprefixerOptions) {
         const payload = typeof css === 'string' || css instanceof Buffer ? css : '';
         let output = css;
 
@@ -62,225 +42,7 @@ function StencilStyles() {
         }
 
         return output;
-    };
-
-    /**
-     * Compile SCSS into CSS and return the content
-     *
-     * @param options
-     * @param callback
-     */
-    this.compileScss = (options, callback) => {
-        const params = {
-            data: options.data,
-            outFile: options.dest,
-            functions: options.functions,
-            importer: this.scssImporter,
-            sourceMap: options.sourceMap,
-            sourceMapEmbed: options.sourceMap,
-            fiber: Fiber,
-        };
-        this.compilers.active = this.compilers.scss.primary;
-
-        promisify(dartSass.render)(params)
-            .catch(dartSassErr => {
-                // TODO: track these errors to check if we can get rid of NodeSass entirely
-                console.err('dartSassErr = ', dartSassErr);
-                this.compilers.active = this.compilers.scss.fallback;
-                return promisify(nodeSassFork.render)(params);
-            })
-            .then(result => callback(null, result.css))
-            .catch(nodeSassForkErr => callback(nodeSassForkErr));
-    };
-
-    /**
-     * Generate sass helper functions with access to theme settings
-     *
-     * @param themeSettings
-     * @returns object
-     */
-    this.scssFunctions = (themeSettings) => {
-        const sassFunctions = {};
-
-        sassFunctions['stencilNumber($name, $unit: px)'] = (nameObj, unitObj) => {
-            const name = _.get(themeSettings, nameObj.getValue());
-            const unit = unitObj.getValue();
-            const value = parseFloat(name) || 0;
-
-            return new this.compilers.active.types.Number(value, unit);
-        };
-
-        sassFunctions['stencilColor($name)'] = (nameObj) => {
-            const name = _.get(themeSettings, nameObj.getValue());
-            const val = name && name[0] === '#' ? name.substr(1) : name;
-
-            return name
-                ? new this.compilers.active.types.Color(parseInt('0xff' + val, 16))
-                : this.compilers.active.NULL;
-        };
-
-        sassFunctions['stencilString($name)'] = (nameObj) => {
-            const name = _.get(themeSettings, nameObj.getValue());
-
-            return name
-                ? new this.compilers.active.types.String(name)
-                : this.compilers.active.NULL;
-        };
-
-        sassFunctions['stencilImage($image, $size)'] = (imageObj, sizeObj) => {
-            const sizeRegex = /^\d+x\d+$/g;
-            const image = _.get(themeSettings, imageObj.getValue());
-            const size = _.get(themeSettings, sizeObj.getValue());
-
-            if (image.indexOf('{:size}') !== -1 && sizeRegex.test(size)) {
-                return new this.compilers.active.types.String(image.replace('{:size}', size));
-            } else {
-                return this.compilers.active.NULL;
-            }
-        };
-
-        sassFunctions['stencilFontFamily($name)'] = (nameObj) => {
-            const name = _.get(themeSettings, nameObj.getValue());
-
-            return this.stencilFont(name, 'family');
-        };
-
-        sassFunctions['stencilFontWeight($name)'] = (nameObj) => {
-            const name = _.get(themeSettings, nameObj.getValue());
-
-            return this.stencilFont(name, 'weight');
-        };
-
-        return sassFunctions;
-    };
-
-    /**
-     * The custom importer callback function to pass to the node-sass compiler
-     *
-     * @param url
-     * @param prev
-     * @returns object
-     */
-    this.scssImporter = (url, prev) => {
-        let fullUrl = url + (url.match(/.*\.scss$/) ? '' : '.scss');
-
-        if (prev !== 'stdin') {
-            fullUrl = path.join(path.parse(prev).dir, fullUrl);
-        }
-
-        if (this.files[fullUrl] === undefined) {
-            const possiblePaths = Object.keys(_.pickBy(this.fullUrls, val => val.indexOf(prev) !== -1));
-
-            possiblePaths.find(possiblePath => {
-                const possibleFullUrl = path.join(path.parse(possiblePath).dir, url);
-
-                if (this.files[possibleFullUrl] !== undefined) {
-                    fullUrl = possibleFullUrl;
-
-                    // We found it so lets kick out of the loop
-                    return true;
-                }
-            });
-        }
-
-        if (this.files[fullUrl] === undefined) {
-            return new Error(fullUrl + ' doesn\'t exist!');
-        }
-
-        if (!this.fullUrls[fullUrl]) {
-            this.fullUrls[fullUrl] = [url];
-        } else if (this.fullUrls[fullUrl].indexOf(url) === -1) {
-            this.fullUrls[fullUrl].push(url);
-        }
-
-        return {
-            file: fullUrl,
-            contents: this.files[fullUrl],
-        };
-    };
-
-    /**
-     * Calls the appropriate font parser for a given provider (Google, etc.)
-     *
-     * @param value
-     * @param type
-     * @returns string or null
-     */
-    this.stencilFont = (value, type) => {
-        const provider = value.split('_')[0];
-
-        switch (provider) {
-        case 'Google':
-            return this.googleFontParser(value, type);
-        default:
-            return this.defaultFontParser(value, type);
-        }
-    };
-
-    /**
-     * Removes "Google_" from the value and calls the default parser
-     * Expects the value in the config has a family_weight structure.
-     * Eg value: "Google_Open+Sans_700", "Google_Open+Sans", "Google_Open+Sans_400_sans", "Google_Open+Sans_400,700_sans"
-     * @param value
-     * @param type - 'family' or 'weight'
-     * @returns {*}
-     */
-    this.googleFontParser = (value, type) => {
-        // Splitting the value
-        // Eg: 'Google_Open+Sans_700' -> [Google, Open+Sans, 700]
-        value = value.split('_');
-
-        // Removing the Google value
-        // Eg: [Google, Open+Sans, 700] -> [Open+Sans, 700]
-        value = value.splice(1);
-
-        // Join the value again
-        // Eg: [Open+Sans, 700] -> 'Open+Sans_700'
-        value = value.join('_');
-
-        return this.defaultFontParser(value, type);
-    };
-
-    /**
-     * Returns the font family or weight
-     * Expects the value to have a family_weight structure.
-     * Will convert + to spaces
-     * Eg value: "Open+Sans_700", "Open Sans", "Open+Sans_400_sans", "Open+Sans_400,700_sans"
-     * @param value
-     * @param type - 'family' or 'weight'
-     * @returns {*}
-     */
-    this.defaultFontParser = (value, type) => {
-        const typeFamily = type === 'family';
-        const index = typeFamily ? 0 : 1;
-        let formattedString;
-        let split;
-
-        if (!_.isString(value)) {
-            return this.compilers.active.NULL;
-        }
-
-        split = value.split('_');
-
-        if (_.isEmpty(split[index])) {
-            return this.compilers.active.NULL;
-        }
-
-        formattedString = split[index].split(',')[0];
-        formattedString = formattedString.replace(/\+/g, ' ');
-
-        // Make sure the string has no quotes in it
-        formattedString = formattedString.replace(/'|"/g, '');
-
-        if (typeFamily) {
-            // Wrap the string in quotes since Sass type String
-            // works with quotes and without quotes (it won't add them)
-            // and we end up with font-family: Open Sans with no quotes
-            formattedString = '"' + formattedString + '"';
-        }
-
-        return new this.compilers.active.types.String(formattedString);
-    };
+    }
 }
 
 module.exports = StencilStyles;

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -4,21 +4,32 @@ const _ = require('lodash');
 const autoprefixer = require('autoprefixer');
 const postcss = require('postcss');
 const path = require('path');
-const sass = require('@bigcommerce/node-sass');
+const nodeSassFork = require('@bigcommerce/node-sass');
+const dartSass = require('sass');
+const Fiber = require('fibers');
+const { promisify } = require('util');
 
 function StencilStyles() {
     this.files = {};
     this.fullUrls = {};
 
+    this.compilers = {
+        active: null,
+        scss: {
+            primary: dartSass,
+            fallback: nodeSassFork,
+        },
+    }
+
     /**
      * Compiles the CSS based on which compiler has been specified
      *
-     * @param compiler
+     * @param syntax
      * @param options
      * @param callback
      */
-    this.compileCss = (compiler, options, callback) => {
-        switch(compiler) {
+    this.compileCss = (syntax, options, callback) => {
+        switch(syntax) {
         case 'scss':
             const compilerOptions = {
                 data: options.data,
@@ -28,7 +39,7 @@ function StencilStyles() {
             };
 
             this.files = options.files || {};
-            this.scssCompiler(compilerOptions, (err, css) => {
+            this.compileScss(compilerOptions, (err, css) => {
                 this.files = {};
                 if (err) {
                     return callback(err);
@@ -42,7 +53,7 @@ function StencilStyles() {
 
     this.autoPrefix = (css, autoprefixerOptions) => {
         const payload = typeof css === 'string' || css instanceof Buffer ? css : '';
-        var output = css;
+        let output = css;
 
         try {
             output = postcss([autoprefixer(autoprefixerOptions)]).process(payload).css;
@@ -59,7 +70,7 @@ function StencilStyles() {
      * @param options
      * @param callback
      */
-    this.scssCompiler = (options, callback) => {
+    this.compileScss = (options, callback) => {
         const params = {
             data: options.data,
             outFile: options.dest,
@@ -67,22 +78,19 @@ function StencilStyles() {
             importer: this.scssImporter,
             sourceMap: options.sourceMap,
             sourceMapEmbed: options.sourceMap,
+            fiber: Fiber,
         };
+        this.compilers.active = this.compilers.scss.primary;
 
-        try {
-            sass.render(params, (err, result) => {
-                if (err) {
-                    return callback(err);
-                }
-
-                callback(null, result.css);
-            });
-
-        } catch (e) {
-            process.nextTick(() => {
-                callback(e);
-            });
-        }
+        promisify(dartSass.render)(params)
+            .catch(dartSassErr => {
+                // TODO: track these errors to check if we can get rid of NodeSass entirely
+                console.err('dartSassErr = ', dartSassErr);
+                this.compilers.active = this.compilers.scss.fallback;
+                return promisify(nodeSassFork.render)(params);
+            })
+            .then(result => callback(null, result.css))
+            .catch(nodeSassForkErr => callback(nodeSassForkErr));
     };
 
     /**
@@ -99,7 +107,7 @@ function StencilStyles() {
             const unit = unitObj.getValue();
             const value = parseFloat(name) || 0;
 
-            return new sass.types.Number(value, unit);
+            return new this.compilers.active.types.Number(value, unit);
         };
 
         sassFunctions['stencilColor($name)'] = (nameObj) => {
@@ -107,16 +115,16 @@ function StencilStyles() {
             const val = name && name[0] === '#' ? name.substr(1) : name;
 
             return name
-                ? new sass.types.Color(parseInt('0xff' + val, 16))
-                : sass.NULL;
+                ? new this.compilers.active.types.Color(parseInt('0xff' + val, 16))
+                : this.compilers.active.NULL;
         };
 
         sassFunctions['stencilString($name)'] = (nameObj) => {
             const name = _.get(themeSettings, nameObj.getValue());
 
             return name
-                ? new sass.types.String(name)
-                : sass.NULL;
+                ? new this.compilers.active.types.String(name)
+                : this.compilers.active.NULL;
         };
 
         sassFunctions['stencilImage($image, $size)'] = (imageObj, sizeObj) => {
@@ -125,9 +133,9 @@ function StencilStyles() {
             const size = _.get(themeSettings, sizeObj.getValue());
 
             if (image.indexOf('{:size}') !== -1 && sizeRegex.test(size)) {
-                return new sass.types.String(image.replace('{:size}', size));
+                return new this.compilers.active.types.String(image.replace('{:size}', size));
             } else {
-                return sass.NULL;
+                return this.compilers.active.NULL;
             }
         };
 
@@ -245,18 +253,17 @@ function StencilStyles() {
     this.defaultFontParser = (value, type) => {
         const typeFamily = type === 'family';
         const index = typeFamily ? 0 : 1;
-        var formattedString;
-        var split;
-
+        let formattedString;
+        let split;
 
         if (!_.isString(value)) {
-            return sass.NULL;
+            return this.compilers.active.NULL;
         }
 
         split = value.split('_');
 
         if (_.isEmpty(split[index])) {
-            return sass.NULL;
+            return this.compilers.active.NULL;
         }
 
         formattedString = split[index].split(',')[0];
@@ -272,8 +279,8 @@ function StencilStyles() {
             formattedString = '"' + formattedString + '"';
         }
 
-        return sass.types.String(formattedString);
+        return new this.compilers.active.types.String(formattedString);
     };
-};
+}
 
 module.exports = StencilStyles;

--- a/package-lock.json
+++ b/package-lock.json
@@ -179,6 +179,68 @@
         "sass-graph": "^2.0.1"
       }
     },
+    "@eslint/eslintrc": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
+      "integrity": "sha512-1JTKgrOKAHVivSvOYw+sJOunkBjUOvjqWk1DPja7ZFhIS2mX/4EgTT8M7eTK9jrKhL/FvXXEbQwIs3pg1xp3dg==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.1.1",
+        "espree": "^7.3.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^3.13.1",
+        "lodash": "^4.17.20",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+          "dev": true
+        },
+        "globals": {
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
+      }
+    },
     "@hapi/address": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.1.0.tgz",
@@ -727,23 +789,6 @@
       "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
       "dev": true
     },
-    "ansi-escapes": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-      "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-      "dev": true,
-      "requires": {
-        "type-fest": "^0.11.0"
-      },
-      "dependencies": {
-        "type-fest": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
-          "dev": true
-        }
-      }
-    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -753,6 +798,15 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "anymatch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
     },
     "aproba": {
       "version": "1.2.0",
@@ -867,6 +921,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
+    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -888,7 +947,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
       }
@@ -949,26 +1007,20 @@
         "supports-color": "^2.0.0"
       }
     },
-    "chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "dev": true
-    },
-    "cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dev": true,
+    "chokidar": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
       "requires": {
-        "restore-cursor": "^3.1.0"
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.1",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.5.0"
       }
-    },
-    "cli-width": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
-      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
-      "dev": true
     },
     "cliui": {
       "version": "3.2.0",
@@ -1116,6 +1168,11 @@
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+    },
     "diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -1220,95 +1277,209 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
-      "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.20.0.tgz",
+      "integrity": "sha512-qGi0CTcOGP2OtCQBgWZlQjcTuP0XkIpYFj25XtRTQSHC+umNnp7UMshr2G8SLsRFYDdAPFeHOsiteadmMH02Yw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
+        "@babel/code-frame": "7.12.11",
+        "@eslint/eslintrc": "^0.3.0",
         "ajv": "^6.10.0",
-        "chalk": "^2.1.0",
-        "cross-spawn": "^6.0.5",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
-        "eslint-scope": "^5.0.0",
-        "eslint-utils": "^1.4.3",
-        "eslint-visitor-keys": "^1.1.0",
-        "espree": "^6.1.2",
-        "esquery": "^1.0.1",
+        "enquirer": "^2.3.5",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^2.1.0",
+        "eslint-visitor-keys": "^2.0.0",
+        "espree": "^7.3.1",
+        "esquery": "^1.4.0",
         "esutils": "^2.0.2",
-        "file-entry-cache": "^5.0.1",
+        "file-entry-cache": "^6.0.0",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
         "globals": "^12.1.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^7.0.0",
         "is-glob": "^4.0.0",
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.3.0",
-        "lodash": "^4.17.14",
+        "levn": "^0.4.1",
+        "lodash": "^4.17.20",
         "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.8.3",
+        "optionator": "^0.9.1",
         "progress": "^2.0.0",
-        "regexpp": "^2.0.1",
-        "semver": "^6.1.2",
-        "strip-ansi": "^5.2.0",
-        "strip-json-comments": "^3.0.1",
-        "table": "^5.2.3",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
+        "table": "^6.0.4",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+          "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
         "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "^2.0.1"
           }
+        },
+        "astral-regex": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+          "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+          "dev": true
         },
         "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
           }
         },
-        "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "eslint-scope": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+          "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+          "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+          "dev": true
+        },
+        "esquery": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+          "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+          "dev": true,
+          "requires": {
+            "estraverse": "^5.1.0"
           },
           "dependencies": {
-            "semver": {
-              "version": "5.7.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "estraverse": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+              "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
               "dev": true
             }
+          }
+        },
+        "esrecurse": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+          "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+          "dev": true,
+          "requires": {
+            "estraverse": "^5.2.0"
+          },
+          "dependencies": {
+            "estraverse": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+              "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+              "dev": true
+            }
+          }
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+          "dev": true
+        },
+        "file-entry-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.0.tgz",
+          "integrity": "sha512-fqoO76jZ3ZnYrXLDRxBR1YvOvc0k844kcOg40bgsPrE25LAb/PDqTY+ho64Xh2c8ZXgIKldchCFHczG2UVRcWA==",
+          "dev": true,
+          "requires": {
+            "flat-cache": "^3.0.4"
+          }
+        },
+        "flat-cache": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+          "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+          "dev": true,
+          "requires": {
+            "flatted": "^3.1.0",
+            "rimraf": "^3.0.2"
+          }
+        },
+        "flatted": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
+          "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "globals": {
@@ -1321,10 +1492,37 @@
           }
         },
         "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
         },
         "minimatch": {
           "version": "3.0.4",
@@ -1335,29 +1533,104 @@
             "brace-expansion": "^1.1.7"
           }
         },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "slice-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+          "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
           }
         },
         "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "^4.0.0"
           }
+        },
+        "table": {
+          "version": "6.0.7",
+          "resolved": "https://registry.npmjs.org/table/-/table-6.0.7.tgz",
+          "integrity": "sha512-rxZevLGTUzWna/qBLObOe16kB2RTnnbhciwgPbMMlazz1yZGVEgnZK762xyVdVznhqxrfCeBMmMkgOOaPwjH7g==",
+          "dev": true,
+          "requires": {
+            "ajv": "^7.0.2",
+            "lodash": "^4.17.20",
+            "slice-ansi": "^4.0.0",
+            "string-width": "^4.2.0"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "7.1.1",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.1.1.tgz",
+              "integrity": "sha512-ga/aqDYnUy/o7vbsRTFhhTsNeXiYb5JWDIcRIeZfwRNCefwjNTVYCGdGSUrEmiu3yDK3vFvNbgJxvrQW4JXrYQ==",
+              "dev": true,
+              "requires": {
+                "fast-deep-equal": "^3.1.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2",
+                "uri-js": "^4.2.2"
+              }
+            }
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
         }
       }
     },
@@ -1372,9 +1645,9 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
-      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
@@ -1387,14 +1660,28 @@
       "dev": true
     },
     "espree": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
-      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
       "dev": true,
       "requires": {
-        "acorn": "^7.1.1",
-        "acorn-jsx": "^5.2.0",
-        "eslint-visitor-keys": "^1.1.0"
+        "acorn": "^7.4.0",
+        "acorn-jsx": "^5.3.1",
+        "eslint-visitor-keys": "^1.3.0"
+      },
+      "dependencies": {
+        "acorn-jsx": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+          "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+          "dev": true
+        },
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
       }
     },
     "esprima": {
@@ -1446,17 +1733,6 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
     },
-    "external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "dev": true,
-      "requires": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
-      }
-    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -1501,13 +1777,12 @@
         "reusify": "^1.0.4"
       }
     },
-    "figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "dev": true,
+    "fibers": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fibers/-/fibers-5.0.0.tgz",
+      "integrity": "sha512-UpGv/YAZp7mhKHxDvC1tColrroGRX90sSvh8RMZV9leo+e5+EkRVgCEZPlmXeo3BUNQTZxUaVdLskq1Q2FyCPg==",
       "requires": {
-        "escape-string-regexp": "^1.0.5"
+        "detect-libc": "^1.0.3"
       }
     },
     "file-entry-cache": {
@@ -1523,7 +1798,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -1623,6 +1897,12 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "optional": true
+    },
     "fstream": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
@@ -1720,7 +2000,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
       "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
-      "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -1898,15 +2177,6 @@
         "sshpk": "^1.7.0"
       }
     },
-    "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
-    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -1956,111 +2226,6 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc="
     },
-    "inquirer": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
-      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.1.0",
-        "cli-cursor": "^3.1.0",
-        "cli-width": "^3.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^3.0.0",
-        "lodash": "^4.17.19",
-        "mute-stream": "0.0.8",
-        "run-async": "^2.4.0",
-        "rxjs": "^6.6.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "through": "^2.3.6"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "dev": true,
-          "requires": {
-            "@types/color-name": "^1.1.1",
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
@@ -2077,6 +2242,14 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
@@ -2092,8 +2265,7 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-finite": {
       "version": "1.0.2",
@@ -2121,7 +2293,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-      "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -2129,8 +2300,7 @@
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-regex": {
       "version": "1.0.4",
@@ -2248,13 +2418,13 @@
       }
     },
     "levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
       }
     },
     "load-json-file": {
@@ -2356,12 +2526,6 @@
         "mime-db": "1.40.0"
       }
     },
-    "mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true
-    },
     "minimatch": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
@@ -2397,12 +2561,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "mute-stream": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-      "dev": true
-    },
     "nan": {
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
@@ -2418,12 +2576,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true
-    },
-    "nice-try": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
     "node-gyp": {
@@ -2496,6 +2648,11 @@
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
       }
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
     "normalize-range": {
       "version": "0.1.2",
@@ -2597,27 +2754,18 @@
         "wrappy": "1"
       }
     },
-    "onetime": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.1.tgz",
-      "integrity": "sha512-ZpZpjcJeugQfWsfyQlshVoowIIQ1qBGSVll4rfDq6JJVO//fesjoX808hXWfBjY+ROZgpKDI5TRSRBSoJiZ8eg==",
-      "dev": true,
-      "requires": {
-        "mimic-fn": "^2.1.0"
-      }
-    },
     "optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
       }
     },
     "os-homedir": {
@@ -2683,9 +2831,9 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
     "path-parse": {
@@ -2718,8 +2866,7 @@
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "dev": true
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
     },
     "pify": {
       "version": "2.3.0",
@@ -2771,9 +2918,9 @@
       "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE="
     },
     "prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
     "process-nextick-args": {
@@ -2845,6 +2992,14 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "readdirp": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -2855,9 +3010,9 @@
       }
     },
     "regexpp": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
       "dev": true
     },
     "repeating": {
@@ -2900,6 +3055,12 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
+    },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
@@ -2918,16 +3079,6 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
-    },
-    "restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dev": true,
-      "requires": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      }
     },
     "reusify": {
       "version": "1.0.4",
@@ -2966,26 +3117,11 @@
         }
       }
     },
-    "run-async": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
-      "dev": true
-    },
     "run-parallel": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
       "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
       "dev": true
-    },
-    "rxjs": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.2.tgz",
-      "integrity": "sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.9.0"
-      }
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -3002,6 +3138,14 @@
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
       "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
       "dev": true
+    },
+    "sass": {
+      "version": "1.32.7",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.7.tgz",
+      "integrity": "sha512-C8Z4bjqGWnsYa11o8hpKAuoyFdRhrSHcYjCr+XAWVPSIQqC8mp2f5Dx4em0dKYehPzg5XSekmCjqJnEZbIls9A==",
+      "requires": {
+        "chokidar": ">=2.0.0 <4.0.0"
+      }
     },
     "sass-graph": {
       "version": "2.2.4",
@@ -3063,18 +3207,18 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "^3.0.0"
       }
     },
     "shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
     "sigmund": {
@@ -3359,21 +3503,6 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
-    },
-    "tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
-      "requires": {
-        "os-tmpdir": "~1.0.2"
-      }
-    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -3384,7 +3513,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "requires": {
         "is-number": "^7.0.0"
       }
@@ -3410,12 +3538,6 @@
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
     },
-    "tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
-      "dev": true
-    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -3430,12 +3552,12 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "^1.2.1"
       }
     },
     "type-fest": {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,10 @@
   "dependencies": {
     "@bigcommerce/node-sass": "git://github.com/bigcommerce-labs/node-sass.git#v3.5.0",
     "autoprefixer": "^6.7.3",
+    "fibers": "^5.0.0",
     "lodash": "4.17.19",
-    "postcss": "^5.2.14"
+    "postcss": "^5.2.14",
+    "sass": "~1.32.7"
   },
   "devDependencies": {
     "@hapi/code": "^8.0.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test-cov-html": "lab -r html -o coverage.html"
   },
   "engines": {
-    "node": ">= 6.0.0 <13.0.0"
+    "node": ">10.8.0 <13.0.0"
   },
   "repository": {
     "type": "git",
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@hapi/code": "^8.0.2",
     "@hapi/lab": "^23.0.0",
-    "eslint": "^6.8.0",
+    "eslint": "^7.20.0",
     "sinon": "^1.14.1"
   }
 }

--- a/test/ScssCompiler.js
+++ b/test/ScssCompiler.js
@@ -1,0 +1,445 @@
+const Code = require('@hapi/code');
+const Os = require('os');
+const Lab = require('@hapi/lab');
+const sinon = require('sinon');
+const nodeSassFork = require('@bigcommerce/node-sass');
+const dartSass = require('sass');
+const Fiber = require('fibers');
+const ScssCompiler = require("../lib/ScssCompiler");
+const themeSettingsMock = require('./mocks/settings.json');
+
+const lab = exports.lab = Lab.script();
+const beforeEach = lab.beforeEach;
+const describe = lab.experiment;
+const expect = Code.expect;
+const it = lab.it;
+
+const osPath = path => Os.platform() === 'win32' ? path.replace(/\//g, '\\') : path;
+
+describe('ScssCompiler', () => {
+    const getRenderResultMock = () => ({
+        css: 'a { color: blue; }',
+    });
+    const getPrimaryEngineStub = (errorMock = null, resultMock = getRenderResultMock()) => ({
+        render: sinon.stub().yields(errorMock, resultMock),
+        types: dartSass.types,
+    });
+    const getFallbackEngineStub = (errorMock = null, resultMock = getRenderResultMock()) => ({
+        render: sinon.stub().yields(errorMock, resultMock),
+        types: nodeSassFork.types,
+    });
+    let getLoggerStub = () => ({
+        error: sinon.stub(),
+    });
+    const getCompilerFilesMock = () => ({
+        [osPath('/mock/path1.scss')]: 'color: #fff',
+        [osPath('/mock/path2.scss')]: 'color: #000',
+        [osPath('/mock/path3.scss')]: 'color: #aaa',
+    });
+    const createScssCompiler = ({
+        logger: passedLogger,
+        engines: passedEngines = {},
+    } = {}) => {
+        const passedArgs = {
+            logger: passedLogger || getLoggerStub(),
+            engines: {
+                primary: getPrimaryEngineStub(),
+                fallback: getFallbackEngineStub(),
+                ...passedEngines,
+            },
+        };
+        return {
+            passedArgs,
+            scssCompiler: new ScssCompiler(passedArgs.logger, passedArgs.engines),
+        };
+    };
+
+    describe('constructor', () => {
+        it('should use default engines if they weren\'t passed through constructor', () => {
+            const scssCompiler = new ScssCompiler(getLoggerStub());
+
+            expect([...Object.keys(scssCompiler.engines)]).to.be.equal(['primary', 'fallback', 'active']);
+            expect(scssCompiler.engines.primary).to.be.equal(dartSass);
+            expect(scssCompiler.engines.fallback).to.be.equal(nodeSassFork);
+        });
+
+        it('should activate primary engine', () => {
+            const { scssCompiler } = createScssCompiler();
+
+            expect(scssCompiler.engines.active).to.be.equal(scssCompiler.engines.primary);
+        });
+    });
+
+    describe('compile', () => {
+        const getOptionsMock = () => {
+            return {
+                files: getCompilerFilesMock(),
+                autoprefixerOptions: {},
+                themeSetting: { ...themeSettingsMock },
+            };
+        };
+
+        it('should throw an error when we try to reuse the instance for different compilations', async () => {
+            const { scssCompiler } = createScssCompiler()
+
+            const options = getOptionsMock();
+            await scssCompiler.compile(options);
+
+            await expect(scssCompiler.compile(options)).to.reject(Error, /already used/);
+        });
+
+        it('should reset this.files value based on options.files', async () => {
+            const { scssCompiler } = createScssCompiler()
+            scssCompiler.files = {};
+
+            const options = getOptionsMock();
+            await scssCompiler.compile(options);
+
+            expect(scssCompiler.files).to.be.equal(options.files);
+        });
+
+        it('should reset this.files value with an empty object when options.files is empty', async () => {
+            const { scssCompiler } = createScssCompiler()
+            scssCompiler.files = {
+                'a.scss': 'a { color: blue; }',
+            };
+            const options = getOptionsMock();
+            delete options.files;
+
+            await scssCompiler.compile(options);
+
+            expect(scssCompiler.files).to.be.equal({});
+        });
+
+        it('should activate the primary engine on the first try', async () => {
+            const { scssCompiler } = createScssCompiler()
+
+            await scssCompiler.compile(getOptionsMock());
+
+            expect(scssCompiler.engines.active).to.be.equal(scssCompiler.engines.primary);
+        });
+
+        it('should call the primary engine render with proper options on the first try', async () => {
+            const { scssCompiler } = createScssCompiler()
+            const compilerOptions = getOptionsMock();
+            const expectedEngineOptions = {
+                data: compilerOptions.data,
+                outFile: compilerOptions.dest,
+                files: compilerOptions.files,
+                sourceMap: compilerOptions.sourceMap,
+                sourceMapEmbed: compilerOptions.sourceMap,
+                fiber: Fiber,
+                functions: scssCompiler.getScssFunctions(compilerOptions.themeSettings),
+                importer: scssCompiler.scssImporter.bind(scssCompiler),
+            };
+
+            await scssCompiler.compile(compilerOptions);
+
+            expect(scssCompiler.engines.primary.render.calledOnce).to.equal(true);
+            expect(scssCompiler.engines.primary.render.lastCall.args.length).to.equal(2);
+            expect(scssCompiler.engines.primary.render.lastCall.args[0]).to.equal(expectedEngineOptions);
+            expect(scssCompiler.engines.primary.render.lastCall.args[1]).to.be.a.function();
+        });
+
+        it('should return the compiled css from the primary engine when it finishes successfully', async () => {
+            const { scssCompiler } = createScssCompiler()
+
+            const result = await scssCompiler.compile(getOptionsMock());
+
+            expect(result).to.equal(getRenderResultMock().css);
+        });
+
+        describe('when the primary engine fails', () => {
+            it('should log the fail', async () => {
+                const error = new Error('oops');
+                const loggerStub = getLoggerStub();
+                const { scssCompiler } = createScssCompiler({
+                    logger: loggerStub,
+                    engines: {
+                        primary: getPrimaryEngineStub(error),
+                    },
+                })
+
+                await scssCompiler.compile(getOptionsMock());
+
+                expect(loggerStub.error.calledOnce).to.equal(true);
+                expect(loggerStub.error.lastCall.args.length).to.equal(1);
+                expect(loggerStub.error.lastCall.args[0]).to.contain(error.message);
+            });
+
+            it('should activate the fallback engine', async () => {
+                const { scssCompiler } = createScssCompiler({
+                    engines: {
+                        primary: getPrimaryEngineStub(new Error('oops')),
+                    },
+                })
+
+                await scssCompiler.compile(getOptionsMock());
+
+                expect(scssCompiler.engines.active).to.be.equal(scssCompiler.engines.fallback);
+            });
+
+            it('should return the compiled css from the fallback engine when it finishes successfully', async () => {
+                const renderResultMock = getRenderResultMock();
+                const { scssCompiler } = createScssCompiler({
+                    engines: {
+                        primary: getPrimaryEngineStub(new Error('oops')),
+                        fallback: getFallbackEngineStub(null, renderResultMock),
+                    },
+                });
+
+                const compilationResult = await scssCompiler.compile(getOptionsMock());
+
+                expect(compilationResult).to.equal(renderResultMock.css);
+            });
+
+            it('should pass on the thrown error from the fallback engine', async () => {
+                const fallBackEngineError = new Error('Fallback Engine Error');
+                const { scssCompiler } = createScssCompiler({
+                    engines: {
+                        primary: getPrimaryEngineStub(new Error('Primary Engine Error')),
+                        fallback: getFallbackEngineStub(fallBackEngineError),
+                    },
+                });
+
+                await expect(scssCompiler.compile(getOptionsMock())).to.reject(Error, fallBackEngineError.message);
+            });
+        });
+    });
+
+    describe('getScssFunctions', () => {
+        it('should return an array with all required functions', () => {
+            const { scssCompiler } = createScssCompiler()
+
+            const result = scssCompiler.getScssFunctions(themeSettingsMock);
+
+            expect(result).to.be.an.object();
+            expect(Object.keys(result)).to.contain([
+                'stencilNumber($name, $unit: px)',
+                'stencilColor($name)',
+                'stencilString($name)',
+                'stencilImage($image, $size)',
+                'stencilFontFamily($name)',
+                'stencilFontWeight($name)',
+            ]);
+        });
+
+        describe('stencilNumber', () => {
+            let stencilNumber;
+            let saasTypes;
+
+            beforeEach(() => {
+                const { scssCompiler } = createScssCompiler()
+                stencilNumber = scssCompiler.getScssFunctions(themeSettingsMock)['stencilNumber($name, $unit: px)'];
+                saasTypes = scssCompiler.engines.primary.types;
+            });
+
+            it('should return the expected for flat key', () => {
+                const settingName = new saasTypes.String('google-font-size');
+                const unit = new saasTypes.String('em');
+
+                expect(stencilNumber(settingName, unit).getValue()).to.equal(14);
+                expect(stencilNumber(settingName, unit).getUnit()).to.equal('em');
+            });
+
+            it('should return the expected for nested key', () => {
+                const settingName = new saasTypes.String('global.h1.font-size.value');
+                const unit = new saasTypes.String('rem');
+
+                expect(stencilNumber(settingName, unit).getValue()).to.equal(16);
+                expect(stencilNumber(settingName, unit).getUnit()).to.equal('rem');
+            });
+
+            it('should return 0 if passed a wrong setting name', () => {
+                const settingName = new saasTypes.String('wrong-setting');
+                const unit = new saasTypes.String('px');
+
+                expect(stencilNumber(settingName, unit).getValue()).to.equal(0);
+            });
+
+            it('should return 0 if passed a wrong setting value', () => {
+                const settingName = new saasTypes.String('google-font-wrong-size');
+                const unit = new saasTypes.String('px');
+
+                expect(stencilNumber(settingName, unit).getValue()).to.equal(0);
+            });
+
+            it('should return a Sass.types.Number', () => {
+                const settingName = new saasTypes.String('google-font-size');
+                const unit = new saasTypes.String('px');
+
+                expect(stencilNumber(settingName, unit) instanceof saasTypes.Number).to.equal(true);
+            });
+        });
+
+        describe('stencilImage', () => {
+            let stencilImage;
+            let saasTypes;
+
+            beforeEach(() => {
+                const { scssCompiler } = createScssCompiler()
+                stencilImage = scssCompiler.getScssFunctions(themeSettingsMock)['stencilImage($image, $size)'];
+                saasTypes = scssCompiler.engines.active.types;
+            });
+
+            it('should return the expected string value', () => {
+                const image = new saasTypes.String('img-url');
+                const size = new saasTypes.String('img-size');
+
+                expect(stencilImage(image, size).getValue()).to.equal('stencil/1000x400/example.jpg');
+            });
+
+            it('should return null if passed an empty image url value', () => {
+                const image = new saasTypes.String('img-url-empty');
+                const size = new saasTypes.String('img-size');
+
+                expect(stencilImage(image, size)).to.equal(saasTypes.Null.NULL);
+            });
+
+            it('should return null if passed a wrong image url value', () => {
+                const image = new saasTypes.String('img-url-wrong--format');
+                const size = new saasTypes.String('img-size');
+
+                expect(stencilImage(image, size)).to.equal(saasTypes.Null.NULL);
+            });
+
+            it('should return null if passed a wrong image dimension value', () => {
+                const image = new saasTypes.String('img-url');
+                const size = new saasTypes.String('img-size-wrong--format');
+
+                expect(stencilImage(image, size)).to.equal(saasTypes.Null.NULL);
+            });
+
+            it('should return a Sass.types.String', () => {
+                const image = new saasTypes.String('img-url');
+                const size = new saasTypes.String('img-size');
+
+                expect(stencilImage(image, size) instanceof saasTypes.String).to.equal(true);
+            });
+        });
+    });
+
+    describe('scssImporter()', () => {
+        let scssCompiler;
+
+        beforeEach(() => {
+            ({ scssCompiler } = createScssCompiler());
+        });
+
+        it('should return an error if files do not exist', () => {
+            const result = scssCompiler.scssImporter('/path2', 'other/path1.scss');
+
+            expect(result.constructor).to.equal(Error);
+            expect(result.message).to.include("doesn't exist!");
+        });
+
+        it('should return an object with a file name and content', () => {
+            const filesMock = getCompilerFilesMock();
+            scssCompiler.files = filesMock;
+            const result = scssCompiler.scssImporter(osPath('/path2'), osPath('/mock/path1.scss'));
+
+            expect(result).to.be.an.object();
+            expect(result).to.include({ file: osPath('/mock/path2.scss') });
+            expect(result).to.include({ contents: filesMock[osPath('/mock/path2.scss')] });
+        });
+
+        it('should succeed when the extension is passed', () => {
+            const filesMock = getCompilerFilesMock();
+            scssCompiler.files = filesMock;
+            const result = scssCompiler.scssImporter(osPath('/path2'), osPath('/mock/path1.scss'));
+
+            expect(result).to.be.an.object();
+            expect(result).to.include({ file: osPath('/mock/path2.scss') });
+            expect(result).to.include({ contents: filesMock[osPath('/mock/path2.scss')] });
+        });
+
+        it('should succeed when ran from the root path (prev=stdin)', () => {
+            scssCompiler.files = { "file1.scss": 'foo' };
+            const result = scssCompiler.scssImporter('file1', 'stdin');
+
+            expect(result).to.be.an.object();
+            expect(result).to.include({ file: 'file1.scss' });
+            expect(result).to.include({ contents: 'foo' });
+        });
+
+        it('should resolve full url', () => {
+            scssCompiler.files[osPath('/foo/bar/file.scss')] = 'foo';
+            scssCompiler.fullUrls[osPath('/foo/file.scss')] = [osPath('/a/prev.scss')];
+
+            const result = scssCompiler.scssImporter(osPath('/bar/file.scss'), osPath('/a/prev.scss'));
+            expect(result.file).to.equal(osPath('/foo/bar/file.scss'));
+        });
+    });
+
+    describe('stencilFont()', () => {
+        let scssCompiler;
+
+        beforeEach(() => {
+            ({ scssCompiler } = createScssCompiler());
+            sinon.spy(scssCompiler, 'googleFontParser');
+            sinon.spy(scssCompiler, 'defaultFontParser');
+        });
+
+        it('should call the Google font parser for Google fonts', () => {
+            scssCompiler.stencilFont(themeSettingsMock['google-font'], 'family');
+
+            expect(scssCompiler.googleFontParser.calledOnce).to.equal(true);
+        });
+
+        it('should call the default parser if provider is not detected', () => {
+            scssCompiler.stencilFont(themeSettingsMock['native-font'], 'family');
+
+            expect(scssCompiler.defaultFontParser.calledOnce).to.equal(true);
+        });
+    });
+
+    describe('googleFontParser()', () => {
+        const googleFont = 'Google_Open+Sans_400';
+        let scssCompiler;
+
+        beforeEach(() => {
+            ({ scssCompiler } = createScssCompiler());
+            sinon.spy(scssCompiler, 'defaultFontParser');
+        });
+
+        it('should remove the Google_ from the value and call defaultParser', () => {
+            scssCompiler.googleFontParser(googleFont, 'family');
+
+            expect(scssCompiler.defaultFontParser.calledWith('Open+Sans_400', 'family')).to.equal(true);
+        });
+    });
+
+    describe('defaultFontParser()', () => {
+        const nativeFont = 'Times New Roman_400';
+        let scssCompiler;
+
+        beforeEach(() => {
+            ({ scssCompiler } = createScssCompiler());
+        });
+
+        it('should return the font family name', () => {
+            const result = scssCompiler.defaultFontParser(nativeFont, 'family');
+
+            expect(result.getValue()).to.equal('"Times New Roman"');
+        });
+
+        it('should return the font weight', () => {
+            const result = scssCompiler.defaultFontParser(nativeFont, 'weight');
+
+            expect(result.getValue()).to.equal('400');
+        });
+
+        it('should return the first font weight if multiple are defined', () => {
+            const result = scssCompiler.defaultFontParser('Times New Roman_400,700,800', 'weight');
+
+            expect(result.getValue()).to.equal('400');
+        });
+
+        it('should return a typeof Sass.NULL if family / weight is empty', () => {
+            const result = scssCompiler.defaultFontParser(undefined, 'family');
+
+            const saasTypes = scssCompiler.engines.active.types;
+            expect(result).to.equal(saasTypes.Null.NULL);
+        });
+    });
+});

--- a/test/styles.js
+++ b/test/styles.js
@@ -5,7 +5,7 @@ const Code = require('@hapi/code');
 const Os = require('os');
 const Lab = require('@hapi/lab');
 const sinon = require('sinon');
-const Sass = require('@bigcommerce/node-sass');
+const Sass = require('sass');
 const StencilStyles = require('../lib/styles');
 const lab = exports.lab = Lab.script();
 const afterEach = lab.afterEach;
@@ -38,6 +38,7 @@ describe('Stencil-Styles Plugin', () => {
             themeSettings,
         };
         stencilStyles = new StencilStyles();
+        stencilStyles.compilers.active = stencilStyles.compilers.scss.primary;
     });
 
     describe('constructor', () => {
@@ -47,12 +48,10 @@ describe('Stencil-Styles Plugin', () => {
     });
 
     describe('autoPrefix', () => {
-        // TODO: Uncomment when no longer supporting Node 6,7 or update
-        // it('should add vendor prefixes to css rules', () => {
-        //     const prefixedCss = stencilStyles.autoPrefix('a { transform: scale(0.5); }', {});
-        //     expect(prefixedCss).to.contain(['-webkit-transform']);
-        //     done()
-        // });
+        it('should add vendor prefixes to css rules', () => {
+            const prefixedCss = stencilStyles.autoPrefix('a { transform: scale(0.5); display: flex; }');
+            expect(prefixedCss).to.contain(['-ms-flexbox']);
+        });
 
         it('should return an empty string if input is not a string', () => {
             expect(stencilStyles.autoPrefix(null)).to.be.equal('');
@@ -67,19 +66,17 @@ describe('Stencil-Styles Plugin', () => {
     });
 
     describe('compileCss()', () => {
-
         describe('when compilations succeed', () => {
             let callback;
             beforeEach(() => {
                 callback = sinon.spy();
-                sinon.spy(stencilStyles, 'scssCompiler');
+                sinon.spy(stencilStyles, 'compileScss');
 
                 stencilStyles.compileCss('scss', options, callback);
-
             });
 
             it('should call the scss compiler based on the compiler parameter', () => {
-                expect(stencilStyles.scssCompiler.calledOnce).to.equal(true);
+                expect(stencilStyles.compileScss.calledOnce).to.equal(true);
             });
 
             it('should call the callback passed in once compilation is complete', () => {
@@ -91,7 +88,7 @@ describe('Stencil-Styles Plugin', () => {
             });
 
             afterEach(() => {
-                stencilStyles.scssCompiler.restore();
+                stencilStyles.compileScss.restore();
             });
         });
 

--- a/test/styles.js
+++ b/test/styles.js
@@ -1,12 +1,9 @@
-'use strict';
-
-const _ = require('lodash');
 const Code = require('@hapi/code');
-const Os = require('os');
 const Lab = require('@hapi/lab');
 const sinon = require('sinon');
-const Sass = require('sass');
 const StencilStyles = require('../lib/styles');
+const ScssCompiler = require('../lib/ScssCompiler');
+
 const lab = exports.lab = Lab.script();
 const afterEach = lab.afterEach;
 const beforeEach = lab.beforeEach;
@@ -14,36 +11,42 @@ const describe = lab.experiment;
 const expect = Code.expect;
 const it = lab.it;
 
-describe('Stencil-Styles Plugin', () => {
-    let files;
-    let options;
-    let themeSettings;
+describe('StencilStyles Plugin', () => {
     let stencilStyles;
+    let loggerMock;
+    let compilersMock;
+    const scssCompilerResultMock = 'a { color: red; }';
 
-    function osPath(path) {
-        return Os.platform() === 'win32' ? path.replace(/\//g, "\\") : path;
-    }
+    const getCompilersMock = () => ({
+        scss: {
+            compile: sinon.stub().returns(scssCompilerResultMock),
+        },
+    });
+    const getOptionsMock = () => ({
+        files: {},
+        autoprefixerOptions: {},
+        themeSettings: {},
+    });
 
     beforeEach(() => {
-        themeSettings = require('./mocks/settings.json');
-        files = {};
-
-        files[osPath('/mock/path1.scss')] = 'color: #fff';
-        files[osPath('/mock/path2.scss')] = 'color: #000';
-        files[osPath('/mock/path3.scss')] = 'color: #aaa';
-
-        options = {
-            files,
-            autoprefixerOptions: {},
-            themeSettings,
-        };
-        stencilStyles = new StencilStyles();
-        stencilStyles.compilers.active = stencilStyles.compilers.scss.primary;
+        loggerMock = {};
+        compilersMock = getCompilersMock();
+        stencilStyles = new StencilStyles(loggerMock, compilersMock);
     });
 
     describe('constructor', () => {
-        it('should set the fullUrls object to empty', () => {
-            expect(stencilStyles.fullUrls).to.be.empty();
+        it('should use a default logger if none was passed through constructor', () => {
+            const stencilStyles = new StencilStyles();
+
+            expect(stencilStyles.logger).to.be.equal(console);
+        });
+
+        it('should use default compilers if they weren\'t passed through constructor', () => {
+            const stencilStyles = new StencilStyles(loggerMock);
+
+            expect([...Object.keys(stencilStyles.compilers)]).to.be.equal(['scss']);
+            expect(stencilStyles.compilers.scss).to.be.instanceOf(ScssCompiler);
+            expect(stencilStyles.compilers.scss.logger).to.be.equal(loggerMock);
         });
     });
 
@@ -67,264 +70,57 @@ describe('Stencil-Styles Plugin', () => {
 
     describe('compileCss()', () => {
         describe('when compilations succeed', () => {
-            let callback;
+            let autoPrefixResultMock = 'a { color: blue; }';
+
             beforeEach(() => {
-                callback = sinon.spy();
-                sinon.spy(stencilStyles, 'compileScss');
-
-                stencilStyles.compileCss('scss', options, callback);
+                sinon.stub(stencilStyles, 'autoPrefix').returns(autoPrefixResultMock);
             });
-
-            it('should call the scss compiler based on the compiler parameter', () => {
-                expect(stencilStyles.compileScss.calledOnce).to.equal(true);
-            });
-
-            it('should call the callback passed in once compilation is complete', () => {
-                expect(callback.calledOnce).to.equal(true);
-            });
-
-            it('should return error if compilation fails', () => {
-                expect(callback.calledOnce).to.equal(true);
-            });
-
             afterEach(() => {
-                stencilStyles.compileScss.restore();
+                stencilStyles.autoPrefix.restore();
+            });
+
+            it('should call compiler with the compiler options from arguments', async () => {
+                const options = getOptionsMock();
+                // eslint-disable-next-line no-unused-vars
+                const { autoprefixerOptions, ...compilerOptions } = options;
+
+                await stencilStyles.compileCss('scss', options);
+
+                expect(compilersMock.scss.compile.calledOnce).to.equal(true);
+                expect(compilersMock.scss.compile.calledWith(compilerOptions)).to.equal(true);
+            });
+
+            it('should call this.autoPrefix with the result from compiler', async () => {
+                const options = getOptionsMock();
+                const { autoprefixerOptions } = options;
+
+                await stencilStyles.compileCss('scss', options);
+
+                expect(stencilStyles.autoPrefix.calledOnce).to.equal(true);
+                expect(stencilStyles.autoPrefix.calledWith(scssCompilerResultMock, autoprefixerOptions)).to.equal(true);
+            });
+
+            it('should return the final output from autoprefixer', async () => {
+                const result = await stencilStyles.compileCss('scss', getOptionsMock());
+
+                expect(result).to.equal(autoPrefixResultMock);
             });
         });
 
+        it('should return undefined if no compiler found for the specified syntax', async () => {
+            const result = await stencilStyles.compileCss('english', getOptionsMock());
+
+            await expect(result).to.be.undefined();
+        });
 
         describe('when compilations fails', () => {
-            beforeEach(() => {
-                sinon.stub(Sass, 'render').throws("Error");
+            it('should pass on the thrown error from compiler', async () => {
+                const errorMessage = 'Some Error';
+                compilersMock.scss.compile.throws(new Error(errorMessage));
+
+                await expect(stencilStyles.compileCss('scss', getOptionsMock()))
+                    .to.reject(Error, errorMessage);
             });
-
-            afterEach(() => {
-                Sass.render.restore();
-            });
-
-            it('should call the scss compiler based on the compiler parameter', () => {
-                stencilStyles.compileCss('scss', options, (err) => {
-                    expect(err).to.be.an.instanceof(Error);
-                });
-            });
-        });
-    });
-
-    describe('scssFunctions', () => {
-        it('should return an array with all required functions', () => {
-            const result = stencilStyles.scssFunctions(themeSettings);
-
-            expect(result).to.be.an.object();
-            expect(_.keys(result)).to.contain([
-                'stencilNumber($name, $unit: px)',
-                'stencilColor($name)',
-                'stencilString($name)',
-                'stencilImage($image, $size)',
-                'stencilFontFamily($name)',
-                'stencilFontWeight($name)',
-            ]);
-        });
-
-        describe('stencilNumber', () => {
-            let stencilNumber;
-
-            beforeEach(() => {
-                stencilNumber = stencilStyles.scssFunctions(themeSettings)['stencilNumber($name, $unit: px)'];
-            });
-
-            it('should return the expected for flat key', () => {
-                const settingName = new Sass.types.String('google-font-size');
-                const unit = new Sass.types.String('em');
-
-                expect(stencilNumber(settingName, unit).getValue()).to.equal(14);
-                expect(stencilNumber(settingName, unit).getUnit()).to.equal('em');
-            });
-
-            it('should return the expected for nested key', () => {
-                const settingName = new Sass.types.String('global.h1.font-size.value');
-                const unit = new Sass.types.String('rem');
-
-                expect(stencilNumber(settingName, unit).getValue()).to.equal(16);
-                expect(stencilNumber(settingName, unit).getUnit()).to.equal('rem');
-            });
-
-            it('should return 0 if passed a wrong setting name', () => {
-                const settingName = new Sass.types.String('wrong-setting');
-                const unit = new Sass.types.String('px');
-
-                expect(stencilNumber(settingName, unit).getValue()).to.equal(0);
-            });
-
-            it('should return 0 if passed a wrong setting value', () => {
-                const settingName = new Sass.types.String('google-font-wrong-size');
-                const unit = new Sass.types.String('px');
-
-                expect(stencilNumber(settingName, unit).getValue()).to.equal(0);
-            });
-
-            it('should return a Sass.types.Number', () => {
-                const settingName = new Sass.types.String('google-font-size');
-                const unit = new Sass.types.String('px');
-
-                expect(stencilNumber(settingName, unit) instanceof Sass.types.Number).to.equal(true);
-            });
-        });
-
-        describe('stencilImage', () => {
-            let stencilImage;
-
-            beforeEach(() => {
-                stencilImage = stencilStyles.scssFunctions(themeSettings)['stencilImage($image, $size)'];
-            });
-
-            it('should return the expected string value', () => {
-                const image = new Sass.types.String('img-url');
-                const size = new Sass.types.String('img-size');
-
-                expect(stencilImage(image, size).getValue()).to.equal('stencil/1000x400/example.jpg');
-            });
-
-            it('should return null if passed an empty image url value', () => {
-                const image = new Sass.types.String('img-url-empty');
-                const size = new Sass.types.String('img-size');
-
-                expect(stencilImage(image, size)).to.equal(Sass.NULL);
-            });
-
-            it('should return null if passed a wrong image url value', () => {
-                const image = new Sass.types.String('img-url-wrong--format');
-                const size = new Sass.types.String('img-size');
-
-                expect(stencilImage(image, size)).to.equal(Sass.NULL);
-            });
-
-            it('should return null if passed a wrong image dimension value', () => {
-                const image = new Sass.types.String('img-url');
-                const size = new Sass.types.String('img-size-wrong--format');
-
-                expect(stencilImage(image, size)).to.equal(Sass.NULL);
-            });
-
-            it('should return a Sass.types.String', () => {
-                const image = new Sass.types.String('img-url');
-                const size = new Sass.types.String('img-size');
-
-                expect(stencilImage(image, size) instanceof Sass.types.String).to.equal(true);
-            });
-        });
-    });
-
-    describe('scssImporter()', () => {
-        it('should return an error if files do not exist', () => {
-            const result = stencilStyles.scssImporter('/path2', 'other/path1.scss');
-
-            expect(result.constructor).to.equal(Error);
-            expect(result.message).to.include("doesn't exist!");
-        });
-
-        it('should return an object with a file name and content', () => {
-            stencilStyles.files = options.files;
-            const result = stencilStyles.scssImporter(osPath('/path2'), osPath('/mock/path1.scss'));
-
-            expect(result).to.be.an.object();
-            expect(result).to.include({ file: osPath('/mock/path2.scss') });
-            expect(result).to.include({ contents: files[osPath('/mock/path2.scss')] });
-        });
-
-        it('should succeed when the extension is passed', () => {
-            stencilStyles.files = options.files;
-            const result = stencilStyles.scssImporter(osPath('/path2'), osPath('/mock/path1.scss'));
-
-            expect(result).to.be.an.object();
-            expect(result).to.include({ file: osPath('/mock/path2.scss') });
-            expect(result).to.include({ contents: files[osPath('/mock/path2.scss')] });
-        });
-
-        it('should succeed when ran from the root path (prev=stdin)', () => {
-            stencilStyles.files = { "file1.scss": 'foo' };
-            const result = stencilStyles.scssImporter('file1', 'stdin');
-
-            expect(result).to.be.an.object();
-            expect(result).to.include({ file: 'file1.scss' });
-            expect(result).to.include({ contents: 'foo' });
-        });
-
-        it('should resolve full url', () => {
-            stencilStyles.files[osPath('/foo/bar/file.scss')] = 'foo';
-            stencilStyles.fullUrls[osPath('/foo/file.scss')] = [osPath('/a/prev.scss')];
-
-            const result = stencilStyles.scssImporter(osPath('/bar/file.scss'), osPath('/a/prev.scss'));
-            expect(result.file).to.equal(osPath('/foo/bar/file.scss'));
-        });
-    });
-
-    describe('stencilFont()', () => {
-        beforeEach(() => {
-            sinon.spy(stencilStyles, 'googleFontParser');
-            sinon.spy(stencilStyles, 'defaultFontParser');
-        });
-
-        it('should call the Google font parser for Google fonts', () => {
-            stencilStyles.stencilFont(themeSettings['google-font'], 'family');
-
-            expect(stencilStyles.googleFontParser.calledOnce).to.equal(true);
-        });
-
-        it('should call the default parser if provider is not detected', () => {
-            stencilStyles.stencilFont(themeSettings['native-font'], 'family');
-
-            expect(stencilStyles.defaultFontParser.calledOnce).to.equal(true);
-        });
-
-        afterEach(() => {
-            stencilStyles.googleFontParser.restore();
-            stencilStyles.defaultFontParser.restore();
-        });
-    });
-
-    describe('googleFontParser()', () => {
-        beforeEach(() => {
-            sinon.spy(stencilStyles, 'defaultFontParser');
-        });
-
-        const googleFont = 'Google_Open+Sans_400';
-
-        it('should remove the Google_ from the value and call defaultParser', () => {
-            stencilStyles.googleFontParser(googleFont, 'family');
-
-            expect(stencilStyles.defaultFontParser.calledWith('Open+Sans_400', 'family')).to.equal(true);
-        });
-
-        afterEach(() => {
-            stencilStyles.defaultFontParser.restore();
-        });
-    });
-
-    describe('defaultFontParser()', () => {
-        const nativeFont = 'Times New Roman_400';
-
-        it('should return the font family name', () => {
-            const result = stencilStyles.defaultFontParser(nativeFont, 'family');
-
-            expect(result.getValue()).to.equal('"Times New Roman"');
-        });
-
-        it('should return the font weight', () => {
-            const result = stencilStyles.defaultFontParser(nativeFont, 'weight');
-
-            expect(result.getValue()).to.equal('400');
-        });
-
-        it('should return the first font weight if multiple are defined', () => {
-            const result = stencilStyles.defaultFontParser('Times New Roman_400,700,800', 'weight');
-
-            expect(result.getValue()).to.equal('400');
-        });
-
-        it('should return a typeof Sass.NULL if family / weight is empty', () => {
-            const result = stencilStyles.defaultFontParser(undefined, 'family');
-
-            expect(result instanceof Sass.types.Null).to.equal(true);
         });
     });
 });


### PR DESCRIPTION
List of changes:
- Implemented a way to run both dart-sass and node-saas fork to compile the styles: firstly we try to compile CSS with dart-sass, if it fails we try again with our node-saas fork.
- Refactored the code into a modern way with ES classes and async/await, emitted ScssCompiler into a separate class, and refactored tests.
- Removed unused register function from index.js.
- Updated ESLint and dropped node 8 support
