### PR TITLE
STRF-9357 Upgrade dart sass to latest version on stencil styles

### DIFF
--- a/lib/ScssCompiler.js
+++ b/lib/ScssCompiler.js
@@ -73,6 +73,7 @@ class ScssCompiler {
             fiber: Fiber,
             functions: this.getScssFunctions(options.themeSettings),
             importer: this.scssImporter.bind(this),
+            quietDeps: true, // suppress deprecation warnings
         };
         let result = {};
         try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "fibers": "^5.0.0",
         "lodash": "4.17.19",
         "postcss": "^5.2.14",
-        "sass": "~1.32.7"
+        "sass": "^1.42.0"
       },
       "devDependencies": {
         "@hapi/code": "^8.0.2",
@@ -3574,9 +3574,9 @@
       "dev": true
     },
     "node_modules/sass": {
-      "version": "1.32.13",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.13.tgz",
-      "integrity": "sha512-dEgI9nShraqP7cXQH+lEXVf73WOPCse0QlFzSD8k+1TcOxCMwVXfQlr0jtoluZysQOyJGnfr21dLvYKDJq8HkA==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.42.0.tgz",
+      "integrity": "sha512-kcjxsemgaOnfl43oZgO/IePLvXQI0ZKzo0/xbCt6uyrg3FY/FF8hVK9YoO8GiZBcEG2Ebl79EKnUc+aiE4f2Vw==",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0"
       },
@@ -7182,9 +7182,9 @@
       "dev": true
     },
     "sass": {
-      "version": "1.32.13",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.13.tgz",
-      "integrity": "sha512-dEgI9nShraqP7cXQH+lEXVf73WOPCse0QlFzSD8k+1TcOxCMwVXfQlr0jtoluZysQOyJGnfr21dLvYKDJq8HkA==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.42.0.tgz",
+      "integrity": "sha512-kcjxsemgaOnfl43oZgO/IePLvXQI0ZKzo0/xbCt6uyrg3FY/FF8hVK9YoO8GiZBcEG2Ebl79EKnUc+aiE4f2Vw==",
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "fibers": "^5.0.0",
     "lodash": "4.17.19",
     "postcss": "^5.2.14",
-    "sass": "~1.32.7"
+    "sass": "^1.42.0"
   },
   "devDependencies": {
     "@hapi/code": "^8.0.2",

--- a/test/ScssCompiler.js
+++ b/test/ScssCompiler.js
@@ -131,6 +131,7 @@ describe('ScssCompiler', () => {
                 fiber: Fiber,
                 functions: scssCompiler.getScssFunctions(compilerOptions.themeSettings),
                 importer: scssCompiler.scssImporter.bind(scssCompiler),
+                quietDeps: true,
             };
 
             await scssCompiler.compile(compilerOptions);


### PR DESCRIPTION
and set `quietDeps` to true to suppress deprecation warnings