### PR TITLE
Release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+### 2.1.0 (2021-09-17)
+
+-   STRF-9357 Upgrade dart sass to latest version to suppress deprecation warnings ([59](https://github.com/bigcommerce/stencil-styles/pull/59))
+-   Reduced npm package size ([46](hhttps://github.com/bigcommerce/stencil-styles/pull/46))
+
+### 2.0.0 (2021-09-17)
+
+-  Add support for dart-sass, so it can run in the same process as node-sass ([50](https://github.com/bigcommerce/stencil-styles/pull/50))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-styles",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-styles",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Compiles SCSS for the Stencil Framework",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
-   STRF-9357 Upgrade dart sass to latest version to suppress deprecation warnings ([59](https://github.com/bigcommerce/stencil-styles/pull/59))
-   Reduced npm package size ([46](hhttps://github.com/bigcommerce/stencil-styles/pull/46))