### PR TITLE
STRF-9440 Don't catch an error, let upper level to handle it

### DIFF
--- a/lib/ScssCompiler.js
+++ b/lib/ScssCompiler.js
@@ -80,16 +80,8 @@ class ScssCompiler {
             importer: this.scssImporter.bind(this),
             quietDeps: true, // suppress deprecation warnings
         };
-        let result = {};
-        try {
-            result = await this._render(engineOptions);
-        } catch (err) {
-            this.logger.error(
-                `Error during css compilation:\n${err}`,
-            );
-        }
+        const result = await this._render(engineOptions);
         this.files = {};
-
         return result.css;
     }
 

--- a/test/ScssCompiler.js
+++ b/test/ScssCompiler.js
@@ -48,6 +48,7 @@ describe('ScssCompiler', () => {
     describe('compile', () => {
         const getOptionsMock = () => {
             return {
+                data: '1',
                 files: getCompilerFilesMock(),
                 autoprefixerOptions: {},
                 themeSetting: { ...themeSettingsMock },
@@ -86,13 +87,11 @@ describe('ScssCompiler', () => {
             expect(scssCompiler.files).to.be.equal({});
         });
 
-        it('should activate the engine on the first try', async () => {
+        it('should throw an error with invalid css provided', async () => {
             const scssCompiler = createScssCompiler();
             scssCompiler.activateNodeSassForkEngine();
 
-            await scssCompiler.compile(getOptionsMock());
-
-            expect(scssCompiler.engine.types).to.be.equal(nodeSassFork.types);
+            await expect(scssCompiler.compile(getOptionsMock())).to.reject(Error, /invalid css/i);
         });
 
         it('should call the engine render with proper options on the first try', async () => {


### PR DESCRIPTION
Currently library is logging an error and preventing the error to be bubbled up in the tree. 
Removing this logic, so upper layers(storefront css and stencil cli) can identify it's own logic to handle errors