### PR TITLE
chore: release 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 5.0.0  (2022-12-30)
+
+-   Drop Node 14 Support and add Node 16 Support  ([79](https://github.com/bigcommerce/stencil-styles/pull/79))
+
 ### 4.0.0  (2022-10-05)
 
 -   Drop Node 12 Support ([76](https://github.com/bigcommerce/stencil-styles/pull/76))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-styles",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-styles",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Compiles SCSS for the Stencil Framework",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
-   Drop Node 14 Support and add Node 16 Support  ([79](https://github.com/bigcommerce/stencil-styles/pull/79))

cc @bigcommerce/storefront-team