### PR TITLE
fix: bump Github Actions versions

### DIFF
--- a/.github/workflows/pull-request-review.yml
+++ b/.github/workflows/pull-request-review.yml
@@ -17,10 +17,10 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: Use Node.js ${{ matrix.node }}
-              uses: actions/setup-node@v2-beta
+              uses: actions/setup-node@v4
               with:
                   node-version: ${{ matrix.node }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,8 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v2
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
               with:
                   node-version: '16.x'
             - run: npm ci


### PR DESCRIPTION
Old versions are deprecated, bumped to v4