### PR TITLE
chore: release 5.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### 5.2.0  (2023-11-24)
 
+-   feat: bump node-sass version ([90](https://github.com/bigcommerce/stencil-styles/pull/90))
+
+### 5.3.0  (2024-01-29)
+
 -   feat(STRF-11419): Create Stylesheets resolver to get css files by stylesheet helper  ([87](https://github.com/bigcommerce/stencil-styles/pull/87))
 
 ### 5.1.0  (2022-01-20)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-styles",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-styles",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "Compiles SCSS for the Stencil Framework",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
-   feat: bump node-sass version ([90](https://github.com/bigcommerce/stencil-styles/pull/90))