### PR TITLE
chore: release 5.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 5.3.2  (2024-02-16)
+
+-   fix: STRF-11740 Rewrote logic for retrieving stylesheets  ([94](https://github.com/bigcommerce/stencil-styles/pull/94))
+
 ### 5.3.1  (2024-02-15)
 
 -   fix: STRF-11740 track commented out stylesheet helpers  ([92](https://github.com/bigcommerce/stencil-styles/pull/92))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-styles",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-styles",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "Compiles SCSS for the Stencil Framework",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
-   fix: STRF-11740 Rewrote logic for retrieving stylesheets  ([94](https://github.com/bigcommerce/stencil-styles/pull/94))