### PR TITLE
chore: release 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 6.0.0  (2024-02-19)
+
+-   feat: STRF-12387 Support Node 20, drop node 16 ([106](https://github.com/bigcommerce/stencil-styles/pull/106))
+
 ### 5.3.3  (2024-02-19)
 
 -   fix: null and duplicated cases for css resolver ([97](https://github.com/bigcommerce/stencil-styles/pull/97))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-styles",
-  "version": "5.3.3",
+  "version": "6.0.0",
   "description": "Compiles SCSS for the Stencil Framework",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
-   feat: STRF-12387 Support Node 20, drop node 16 ([106](https://github.com/bigcommerce/stencil-styles/pull/106))
