### PR TITLE
chore: release 6.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-### 6.0.0  (2024-02-19)
+### 6.0.1  (2024-09-06)
+
+-   fix: STRF-12387 Bump postcss and sinon ([108](https://github.com/bigcommerce/stencil-styles/pull/108))
+
+### 6.0.0  (2024-09-05)
 
 -   feat: STRF-12387 Support Node 20, drop node 16 ([106](https://github.com/bigcommerce/stencil-styles/pull/106))
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-styles",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Compiles SCSS for the Stencil Framework",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
-   fix: STRF-12387 Bump postcss and sinon ([108](https://github.com/bigcommerce/stencil-styles/pull/108))
