### PR TITLE
chore: release 6.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 6.1.1  (2024-09-17)
+
+-   feat: STRF-11834 Consolidate css assembling logic ([117](https://github.com/bigcommerce/stencil-styles/pull/117))
+
 ### 6.0.1  (2024-09-06)
 
 -   fix: STRF-12387 Bump postcss and sinon ([108](https://github.com/bigcommerce/stencil-styles/pull/108))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-styles",
-  "version": "6.0.1",
+  "version": "6.1.1",
   "description": "Compiles SCSS for the Stencil Framework",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
-   feat: STRF-11834 Consolidate css assembling logic ([117](https://github.com/bigcommerce/stencil-styles/pull/117))
