### PR TITLE
Add stencilBoolean function to SCSS compiler

### DIFF
--- a/lib/ScssCompiler.js
+++ b/lib/ScssCompiler.js
@@ -100,23 +100,11 @@ class ScssCompiler {
     getScssFunctions(themeSettings) {
         const sassFunctions = {};
 
-        /**
-         * helper function for wrangling booleans
-         *
-         * @param value value to parse
-         * @returns {boolean}
-         * @private
-         */
-        const __parseBoolean = (value) => {
-            if (typeof value === "string") {
-                return value.trim().toLowerCase() === "true";
-            }
-            return Boolean(value); // Fallback for actual booleans or numbers
-        }
 
         sassFunctions['stencilBoolean($name)'] = (nameObj) => {
             const name = _.get(themeSettings, nameObj.getValue());
-            const value = __parseBoolean(name) || false;
+            // https://developer.mozilla.org/en-US/docs/Glossary/Truthy
+            const value = Boolean(name);
 
             return value ? this.saasTypes.Boolean.TRUE : this.saasTypes.Boolean.FALSE;
         };

--- a/lib/ScssCompiler.js
+++ b/lib/ScssCompiler.js
@@ -100,6 +100,20 @@ class ScssCompiler {
     getScssFunctions(themeSettings) {
         const sassFunctions = {};
 
+        const __parseBoolean = (value) => {
+            if (typeof value === "string") {
+                return value.trim().toLowerCase() === "true";
+            }
+            return Boolean(value); // Fallback for actual booleans or numbers
+        }
+
+        sassFunctions['stencilBoolean($name)'] = (nameObj) => {
+            const name = _.get(themeSettings, nameObj.getValue());
+            const value = __parseBoolean(name) || false;
+
+            return new this.saasTypes.Number(value ? 1 : 0);
+        };
+        
         sassFunctions['stencilNumber($name, $unit: px)'] = (nameObj, unitObj) => {
             const name = _.get(themeSettings, nameObj.getValue());
             const unit = unitObj.getValue();

--- a/lib/ScssCompiler.js
+++ b/lib/ScssCompiler.js
@@ -100,6 +100,27 @@ class ScssCompiler {
     getScssFunctions(themeSettings) {
         const sassFunctions = {};
 
+        /**
+         * helper function for wrangling booleans
+         *
+         * @param value value to parse
+         * @returns {boolean}
+         * @private
+         */
+        const __parseBoolean = (value) => {
+            if (typeof value === "string") {
+                return value.trim().toLowerCase() === "true";
+            }
+            return Boolean(value); // Fallback for actual booleans or numbers
+        }
+
+        sassFunctions['stencilBoolean($name)'] = (nameObj) => {
+            const name = _.get(themeSettings, nameObj.getValue());
+            const value = __parseBoolean(name) || false;
+
+            return value ? this.saasTypes.Boolean.TRUE : this.saasTypes.Boolean.FALSE;
+        };
+        
         sassFunctions['stencilNumber($name, $unit: px)'] = (nameObj, unitObj) => {
             const name = _.get(themeSettings, nameObj.getValue());
             const unit = unitObj.getValue();

--- a/test/ScssCompiler.js
+++ b/test/ScssCompiler.js
@@ -165,36 +165,38 @@ describe('ScssCompiler', () => {
 
             it('should return the expected for flat key', () => {
                 const settingName = {
-                    "truthy-literal"                    : new saasTypes.String("truthy-literal"),
-                    "truthy-string"                     : new saasTypes.String("truthy-string"),
-                    "falsey-literal"                    : new saasTypes.String("falsey-literal"),
-                    "falsey-string-fallback-literal"    : new saasTypes.String("falsey-string-fallback-literal"),
-                    "falsey-string-fallback-any"        : new saasTypes.String("falsey-string-fallback-any"),
+                    "truthy-literal": new saasTypes.String("truthy-literal"),
+                    "truthy-string": new saasTypes.String("truthy-string"),
+                    "truthy-number": new saasTypes.String("truthy-number"),
+                    "falsey-literal": new saasTypes.String("falsey-literal"),
+                    "falsey-string": new saasTypes.String("falsey-string"),
+                    "falsy-number": new saasTypes.String("falsy-number"),
                 };
 
                 expect(stencilBoolean(settingName["truthy-literal"]).getValue()).to.equal(true);
                 expect(stencilBoolean(settingName["truthy-string"]).getValue()).to.equal(true);
+                expect(stencilBoolean(settingName["truthy-number"]).getValue()).to.equal(true);
                 expect(stencilBoolean(settingName["falsey-literal"]).getValue()).to.equal(false);
-                expect(stencilBoolean(settingName["falsey-string-fallback-literal"]).getValue()).to.equal(false);
-                expect(stencilBoolean(settingName["falsey-string-fallback-any"]).getValue()).to.equal(false);
-
+                expect(stencilBoolean(settingName["falsey-string"]).getValue()).to.equal(false);
+                expect(stencilBoolean(settingName["falsy-number"]).getValue()).to.equal(false);
             });
 
             it('should return the expected for nested key', () => {
-
                 const settingName = {
                     "global.truthy-literal": new saasTypes.String("global.truthy-literal"),
                     "global.truthy-string": new saasTypes.String("global.truthy-string"),
+                    "global.truthy-number": new saasTypes.String("global.truthy-number"),
                     "global.falsey-literal": new saasTypes.String("global.falsey-literal"),
-                    "global.falsey-string-fallback-literal": new saasTypes.String("global.falsey-string-fallback-literal"),
-                    "global.falsey-string-fallback-any": new saasTypes.String("global.falsey-string-fallback-any"),
+                    "global.falsey-string": new saasTypes.String("global.falsey-string"),
+                    "global.falsy-number": new saasTypes.String("global.falsy-number"),
                 };
 
                 expect(stencilBoolean(settingName["global.truthy-literal"]).getValue()).to.equal(true);
                 expect(stencilBoolean(settingName["global.truthy-string"]).getValue()).to.equal(true);
+                expect(stencilBoolean(settingName["global.truthy-number"]).getValue()).to.equal(true);
                 expect(stencilBoolean(settingName["global.falsey-literal"]).getValue()).to.equal(false);
-                expect(stencilBoolean(settingName["global.falsey-string-fallback-literal"]).getValue()).to.equal(false);
-                expect(stencilBoolean(settingName["global.falsey-string-fallback-any"]).getValue()).to.equal(false);
+                expect(stencilBoolean(settingName["global.falsey-string"]).getValue()).to.equal(false);
+                expect(stencilBoolean(settingName["global.falsy-number"]).getValue()).to.equal(false);
             });
 
             it('should return false if passed a wrong setting name', () => {
@@ -208,9 +210,11 @@ describe('ScssCompiler', () => {
             it('should return a Sass.types.Boolean', () => {
                 const settingName = {
                     "truthy-literal": new saasTypes.String("truthy-literal"),
+                    "falsey-literal": new saasTypes.String("falsey-literal"),
                 }
 
                 expect(stencilBoolean(settingName["truthy-literal"]) instanceof saasTypes.Boolean).to.equal(true);
+                expect(stencilBoolean(settingName["falsey-literal"]) instanceof saasTypes.Boolean).to.equal(true);
             });
         });
 

--- a/test/ScssCompiler.js
+++ b/test/ScssCompiler.js
@@ -143,6 +143,7 @@ describe('ScssCompiler', () => {
 
             expect(result).to.be.an.object();
             expect(Object.keys(result)).to.contain([
+                'stencilBoolean($name)',
                 'stencilNumber($name, $unit: px)',
                 'stencilColor($name)',
                 'stencilString($name)',
@@ -150,6 +151,67 @@ describe('ScssCompiler', () => {
                 'stencilFontFamily($name)',
                 'stencilFontWeight($name)',
             ]);
+        });
+
+        describe('stencilBoolean', () => {
+            let stencilBoolean;
+            let saasTypes;
+
+            beforeEach(() => {
+                const scssCompiler = createScssCompiler()
+                stencilBoolean = scssCompiler.getScssFunctions(themeSettingsMock)['stencilBoolean($name)'];
+                saasTypes = scssCompiler.engine.types;
+            });
+
+            it('should return the expected for flat key', () => {
+                const settingName = {
+                    "truthy-literal"                    : new saasTypes.String("truthy-literal"),
+                    "truthy-string"                     : new saasTypes.String("truthy-string"),
+                    "falsey-literal"                    : new saasTypes.String("falsey-literal"),
+                    "falsey-string-fallback-literal"    : new saasTypes.String("falsey-string-fallback-literal"),
+                    "falsey-string-fallback-any"        : new saasTypes.String("falsey-string-fallback-any"),
+                };
+
+                expect(stencilBoolean(settingName["truthy-literal"]).getValue()).to.equal(true);
+                expect(stencilBoolean(settingName["truthy-string"]).getValue()).to.equal(true);
+                expect(stencilBoolean(settingName["falsey-literal"]).getValue()).to.equal(false);
+                expect(stencilBoolean(settingName["falsey-string-fallback-literal"]).getValue()).to.equal(false);
+                expect(stencilBoolean(settingName["falsey-string-fallback-any"]).getValue()).to.equal(false);
+
+            });
+
+            it('should return the expected for nested key', () => {
+
+                const settingName = {
+                    "global.truthy-literal": new saasTypes.String("global.truthy-literal"),
+                    "global.truthy-string": new saasTypes.String("global.truthy-string"),
+                    "global.falsey-literal": new saasTypes.String("global.falsey-literal"),
+                    "global.falsey-string-fallback-literal": new saasTypes.String("global.falsey-string-fallback-literal"),
+                    "global.falsey-string-fallback-any": new saasTypes.String("global.falsey-string-fallback-any"),
+                };
+
+                expect(stencilBoolean(settingName["global.truthy-literal"]).getValue()).to.equal(true);
+                expect(stencilBoolean(settingName["global.truthy-string"]).getValue()).to.equal(true);
+                expect(stencilBoolean(settingName["global.falsey-literal"]).getValue()).to.equal(false);
+                expect(stencilBoolean(settingName["global.falsey-string-fallback-literal"]).getValue()).to.equal(false);
+                expect(stencilBoolean(settingName["global.falsey-string-fallback-any"]).getValue()).to.equal(false);
+            });
+
+            it('should return false if passed a wrong setting name', () => {
+                const settingName = {
+                    "bad-value": new saasTypes.String("bad-value"),
+                };
+
+                expect(stencilBoolean(settingName["bad-value"]).getValue()).to.equal(false);
+            });
+
+            it('should return a Sass.types.Boolean', () => {
+                const settingName = {
+                    "truthy-literal": new saasTypes.String("truthy-literal"),
+                }
+
+                expect(stencilBoolean(settingName["truthy-literal"]) instanceof saasTypes.Boolean).to.equal(true);
+            });
         });
 
         describe('stencilNumber', () => {

--- a/test/mocks/settings.json
+++ b/test/mocks/settings.json
@@ -18,13 +18,15 @@
     },
     "truthy-literal": true,
     "truthy-string": "true",
+    "truthy-number": 1,
     "falsey-literal": false,
-    "falsey-string-fallback-literal": "false",
-    "falsey-string-fallback-any": "any-non-true-string-is-false"
+    "falsey-string": "",
+    "falsy-number": 0
   },
   "truthy-literal": true,
   "truthy-string": "true",
+  "truthy-number": 1,
   "falsey-literal": false,
-  "falsey-string-fallback-literal": "false",
-  "falsey-string-fallback-any": "any-non-true-string-is-false"
+  "falsey-string": "",
+  "falsy-number": 0
 }

--- a/test/mocks/settings.json
+++ b/test/mocks/settings.json
@@ -15,6 +15,16 @@
       "font-size": {
         "value": 16
       }
-    }
-  }
+    },
+    "truthy-literal": true,
+    "truthy-string": "true",
+    "falsey-literal": false,
+    "falsey-string-fallback-literal": "false",
+    "falsey-string-fallback-any": "any-non-true-string-is-false"
+  },
+  "truthy-literal": true,
+  "truthy-string": "true",
+  "falsey-literal": false,
+  "falsey-string-fallback-literal": "false",
+  "falsey-string-fallback-any": "any-non-true-string-is-false"
 }

--- a/test/mocks/themes/documentation-sample-functions/stencilBoolean.scss
+++ b/test/mocks/themes/documentation-sample-functions/stencilBoolean.scss
@@ -1,0 +1,11 @@
+// Helper function for use with stencilBoolean(...);
+
+/**
+ * Simple casting macro for resolving a true value to 1 and a false value to 0.
+ */
+@function castSASSBooleanForCSS1And0($isSassTruthy) {
+    @if $isSassTruthy {
+        @return 1;
+    }
+    @return 0;
+}

--- a/test/mocks/themes/valid/assets/scss/tools/onemore.scss
+++ b/test/mocks/themes/valid/assets/scss/tools/onemore.scss
@@ -1,3 +1,13 @@
 .underscore {
     color: green;
 }
+
+/**
+ * Simple casting macro for resolving a true value to 1 and a false value to 0.
+ */
+@function castSASSBooleanForCSS1And0($isSassTruthy) {
+    @if $isSassTruthy {
+        @return 1;
+    }
+    @return 0;
+}

--- a/test/mocks/themes/valid/assets/scss/tools/onemore.scss
+++ b/test/mocks/themes/valid/assets/scss/tools/onemore.scss
@@ -1,13 +1,3 @@
 .underscore {
     color: green;
 }
-
-/**
- * Simple casting macro for resolving a true value to 1 and a false value to 0.
- */
-@function castSASSBooleanForCSS1And0($isSassTruthy) {
-    @if $isSassTruthy {
-        @return 1;
-    }
-    @return 0;
-}


### PR DESCRIPTION
#RFC Proposal: Support for Stencil Boolean values in SASS.

## What/Why?
Current state of stencil<type> helpers does not support the processing of `true` or `false` values from `config.json`. These boolean states are configurable via UI and therefore should be importable into SCSS if required, not just into Handlebars.

## Rollout/Rollback
Unknown as this is a outside contribution, in theory it would be to merge and bump all required packages to the new version downstream.

## Testing
Tests are included, cloned from structure for `stencilNumber(...)` and contents replaced to reflect testing for truthiness.

## Documentation:
The following values are considered `true` for the purposes of usage of `stencilBoolean(...)` as per the Javascript Truthy:
```Javascript
if (true);
if ({});
if ([]);
if (42);
if ("0");
if ("false");
if (new Date());
if (-42);
if (12n);
if (3.14);
if (-3.14);
if (Infinity);
if (-Infinity);
```
Any value not in the list above is considered `false` when injected into SASS. Once this state has been transferred from `config.json` to SASS, the way that SASS handles Booleans applies.

See Mozilla Truthy Glossary documentation for more information on Javascript Truthy: [https://developer.mozilla.org/en-US/docs/Glossary/Truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy)
See SASS documentation on Boolean values: [https://sass-lang.com/documentation/values/booleans/](https://sass-lang.com/documentation/values/booleans/)

### Implementation Warning:
CSS does not have a value representation of `true` and `false` and therefore cannot be directly translated from SCSS to CSS. One way to handle this is to use numeric `1` for true and numeric `0` for false, but implementation like this is up to the developer. What follows is a function that can be used in SCSS to perform a cast from SASS truthy to `1` else `0`.

```SCSS
/**
 * Simple casting macro for resolving a true value to 1 and a false value to 0.
 */
@function castSASSBooleanForCSS1And0($isSassTruthy) {
    @if $isSassTruthy {
        @return 1;
    }
    @return 0;
}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive SCSS helper following existing stencil* patterns; no auth or data-path changes, with unit tests covering lookup and coercion behavior.
> 
> **Overview**
> Adds **`stencilBoolean($name)`** to the SCSS compiler’s theme-setting helpers so boolean (and other truthy/falsy) values from `config.json` can drive Sass `@if` and similar logic, alongside existing helpers like `stencilNumber`.
> 
> The function resolves the setting key (including nested paths via `_.get`), applies **JavaScript truthy** coercion with `Boolean(...)`, and returns **`Sass.types.Boolean.TRUE` or `FALSE`**. Missing or invalid keys evaluate to **false**.
> 
> Tests mirror the `stencilNumber` suite (flat/nested keys, bad key, Sass type). Fixture settings and a sample **`castSASSBooleanForCSS1And0`** SCSS helper document mapping booleans to `1`/`0` for CSS output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cf456c283c038ba0b3d9f7c28d3f8763f2878df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->